### PR TITLE
feat: add macOS WidgetKit widget extension

### DIFF
--- a/Usage4Claude.xcodeproj/project.pbxproj
+++ b/Usage4Claude.xcodeproj/project.pbxproj
@@ -38,9 +38,9 @@
 
 /* Begin PBXFileReference section */
 		8873E4CF2E9F61C700ACFF5C /* Usage4Claude.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Usage4Claude.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Usage4ClaudeWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		WIDGET000 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		WIDGET003 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Usage4ClaudeWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -161,7 +161,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 2600;
-				LastUpgradeCheck = 2600;
+				LastUpgradeCheck = 2620;
 				TargetAttributes = {
 					8873E4CE2E9F61C700ACFF5C = {
 						CreatedOnToolsVersion = 26.0.1;
@@ -244,6 +244,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -273,6 +274,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -298,6 +300,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -308,6 +311,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -337,6 +341,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -355,6 +360,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 			};
 			name = Release;
@@ -362,16 +368,18 @@
 		8873E4DB2E9F61C800ACFF5C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Usage4Claude/Usage4Claude.entitlements;
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				ENABLE_APP_SANDBOX = YES;
+				ENABLE_APP_SANDBOX = NO;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
@@ -412,16 +420,18 @@
 		8873E4DC2E9F61C800ACFF5C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Usage4Claude/Usage4Claude.entitlements;
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				ENABLE_APP_SANDBOX = YES;
+				ENABLE_APP_SANDBOX = NO;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
@@ -465,10 +475,13 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements;
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				ENABLE_APP_SANDBOX = YES;
+				ENABLE_APP_SANDBOX = NO;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "";
@@ -502,10 +515,13 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements;
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				ENABLE_APP_SANDBOX = YES;
+				ENABLE_APP_SANDBOX = NO;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "";

--- a/Usage4Claude.xcodeproj/project.pbxproj
+++ b/Usage4Claude.xcodeproj/project.pbxproj
@@ -6,14 +6,52 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		WIDGET001 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WIDGET000 /* WidgetKit.framework */; };
+		WIDGET002 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WIDGET003 /* SwiftUI.framework */; };
+		WIDGET004 /* Usage4ClaudeWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		WIDGETPROXY /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8873E4C72E9F61C700ACFF5C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = WIDGETTARGET;
+			remoteInfo = Usage4ClaudeWidgetExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		WIDGETEMBED /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				WIDGET004 /* Usage4ClaudeWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		8873E4CF2E9F61C700ACFF5C /* Usage4Claude.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Usage4Claude.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Usage4ClaudeWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		WIDGET000 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		WIDGET003 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		8873E4D12E9F61C700ACFF5C /* Usage4Claude */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Usage4Claude;
+			sourceTree = "<group>";
+		};
+		WIDGETGRP /* Usage4ClaudeWidget */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Usage4ClaudeWidget;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -26,6 +64,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		WIDGETFWK /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				WIDGET002 /* SwiftUI.framework in Frameworks */,
+				WIDGET001 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -33,6 +80,8 @@
 			isa = PBXGroup;
 			children = (
 				8873E4D12E9F61C700ACFF5C /* Usage4Claude */,
+				WIDGETGRP /* Usage4ClaudeWidget */,
+				FWKGROUP /* Frameworks */,
 				8873E4D02E9F61C700ACFF5C /* Products */,
 			);
 			sourceTree = "<group>";
@@ -41,8 +90,18 @@
 			isa = PBXGroup;
 			children = (
 				8873E4CF2E9F61C700ACFF5C /* Usage4Claude.app */,
+				WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		FWKGROUP /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				WIDGET000 /* WidgetKit.framework */,
+				WIDGET003 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -55,10 +114,12 @@
 				8873E4CB2E9F61C700ACFF5C /* Sources */,
 				8873E4CC2E9F61C700ACFF5C /* Frameworks */,
 				8873E4CD2E9F61C700ACFF5C /* Resources */,
+				WIDGETEMBED /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				WIDGETDEP /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				8873E4D12E9F61C700ACFF5C /* Usage4Claude */,
@@ -69,6 +130,28 @@
 			productName = Usage4Claude;
 			productReference = 8873E4CF2E9F61C700ACFF5C /* Usage4Claude.app */;
 			productType = "com.apple.product-type.application";
+		};
+		WIDGETTARGET /* Usage4ClaudeWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = WIDGETCFGLIST /* Build configuration list for PBXNativeTarget "Usage4ClaudeWidgetExtension" */;
+			buildPhases = (
+				WIDGETSRC /* Sources */,
+				WIDGETFWK /* Frameworks */,
+				WIDGETRES /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				WIDGETGRP /* Usage4ClaudeWidget */,
+			);
+			name = Usage4ClaudeWidgetExtension;
+			packageProductDependencies = (
+			);
+			productName = Usage4ClaudeWidgetExtension;
+			productReference = WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -83,6 +166,9 @@
 					8873E4CE2E9F61C700ACFF5C = {
 						CreatedOnToolsVersion = 26.0.1;
 						LastSwiftMigration = 2600;
+					};
+					WIDGETTARGET = {
+						CreatedOnToolsVersion = 26.0.1;
 					};
 				};
 			};
@@ -105,12 +191,20 @@
 			projectRoot = "";
 			targets = (
 				8873E4CE2E9F61C700ACFF5C /* Usage4Claude */,
+				WIDGETTARGET /* Usage4ClaudeWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		8873E4CD2E9F61C700ACFF5C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		WIDGETRES /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -127,7 +221,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		WIDGETSRC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		WIDGETDEP /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = WIDGETTARGET /* Usage4ClaudeWidgetExtension */;
+			targetProxy = WIDGETPROXY /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		8873E4D82E9F61C800ACFF5C /* Debug */ = {
@@ -253,12 +362,12 @@
 		8873E4DB2E9F61C800ACFF5C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Usage4Claude-CodeSigning";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Usage4Claude-CodeSigning";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_ENTITLEMENTS = Usage4Claude/Usage4Claude.entitlements;
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -303,12 +412,12 @@
 		8873E4DC2E9F61C800ACFF5C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Usage4Claude-CodeSigning";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Usage4Claude-CodeSigning";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_ENTITLEMENTS = Usage4Claude/Usage4Claude.entitlements;
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -349,6 +458,79 @@
 			};
 			name = Release;
 		};
+		WIDGETCFGDEBUG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				INFOPLIST_KEY_CFBundleDisplayName = "Usage4Claude Widget";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 2.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = xyz.fi5h.Usage4Claude.Widget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = minimal;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		WIDGETCFGRELEASE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				INFOPLIST_KEY_CFBundleDisplayName = "Usage4Claude Widget";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 2.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = xyz.fi5h.Usage4Claude.Widget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				SKIP_INSTALL = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = minimal;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -366,6 +548,15 @@
 			buildConfigurations = (
 				8873E4DB2E9F61C800ACFF5C /* Debug */,
 				8873E4DC2E9F61C800ACFF5C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		WIDGETCFGLIST /* Build configuration list for PBXNativeTarget "Usage4ClaudeWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				WIDGETCFGDEBUG /* Debug */,
+				WIDGETCFGRELEASE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Usage4Claude.xcodeproj/project.pbxproj
+++ b/Usage4Claude.xcodeproj/project.pbxproj
@@ -7,29 +7,29 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		WIDGET001 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WIDGET000 /* WidgetKit.framework */; };
-		WIDGET002 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WIDGET003 /* SwiftUI.framework */; };
-		WIDGET004 /* Usage4ClaudeWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		851F88B1F6CCE36B8296DBF6 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 334DEEC8C0AF87D7AE76764D /* WidgetKit.framework */; };
+		554B23CF9491AD6219F536A2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A87739911B7B81D7B91F6F3 /* SwiftUI.framework */; };
+		E22FCD122AD18CF56501A4A2 /* Usage4ClaudeWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 068039FD2F82B5A332FAC8C7 /* Usage4ClaudeWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		WIDGETPROXY /* PBXContainerItemProxy */ = {
+		776710D32DDD1B75B1513839 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8873E4C72E9F61C700ACFF5C /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = WIDGETTARGET;
+			remoteGlobalIDString = AC785F8C97E63874BBA3DA5A;
 			remoteInfo = Usage4ClaudeWidgetExtension;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		WIDGETEMBED /* Embed Foundation Extensions */ = {
+		EDF27352ADEFCA2E8F4DD6F3 /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				WIDGET004 /* Usage4ClaudeWidgetExtension.appex in Embed Foundation Extensions */,
+				E22FCD122AD18CF56501A4A2 /* Usage4ClaudeWidgetExtension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -38,9 +38,9 @@
 
 /* Begin PBXFileReference section */
 		8873E4CF2E9F61C700ACFF5C /* Usage4Claude.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Usage4Claude.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		WIDGET000 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
-		WIDGET003 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
-		WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Usage4ClaudeWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		334DEEC8C0AF87D7AE76764D /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		7A87739911B7B81D7B91F6F3 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		068039FD2F82B5A332FAC8C7 /* Usage4ClaudeWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Usage4ClaudeWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -49,7 +49,7 @@
 			path = Usage4Claude;
 			sourceTree = "<group>";
 		};
-		WIDGETGRP /* Usage4ClaudeWidget */ = {
+		E13350EACE2EC0906F5703CB /* Usage4ClaudeWidget */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Usage4ClaudeWidget;
 			sourceTree = "<group>";
@@ -64,12 +64,12 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		WIDGETFWK /* Frameworks */ = {
+		C7DFE2691DD0776179DE5342 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				WIDGET002 /* SwiftUI.framework in Frameworks */,
-				WIDGET001 /* WidgetKit.framework in Frameworks */,
+				554B23CF9491AD6219F536A2 /* SwiftUI.framework in Frameworks */,
+				851F88B1F6CCE36B8296DBF6 /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -80,8 +80,8 @@
 			isa = PBXGroup;
 			children = (
 				8873E4D12E9F61C700ACFF5C /* Usage4Claude */,
-				WIDGETGRP /* Usage4ClaudeWidget */,
-				FWKGROUP /* Frameworks */,
+				E13350EACE2EC0906F5703CB /* Usage4ClaudeWidget */,
+				857E8F82DC96DD5A2D5BF4DC /* Frameworks */,
 				8873E4D02E9F61C700ACFF5C /* Products */,
 			);
 			sourceTree = "<group>";
@@ -90,16 +90,16 @@
 			isa = PBXGroup;
 			children = (
 				8873E4CF2E9F61C700ACFF5C /* Usage4Claude.app */,
-				WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */,
+				068039FD2F82B5A332FAC8C7 /* Usage4ClaudeWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		FWKGROUP /* Frameworks */ = {
+		857E8F82DC96DD5A2D5BF4DC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				WIDGET000 /* WidgetKit.framework */,
-				WIDGET003 /* SwiftUI.framework */,
+				334DEEC8C0AF87D7AE76764D /* WidgetKit.framework */,
+				7A87739911B7B81D7B91F6F3 /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -114,12 +114,12 @@
 				8873E4CB2E9F61C700ACFF5C /* Sources */,
 				8873E4CC2E9F61C700ACFF5C /* Frameworks */,
 				8873E4CD2E9F61C700ACFF5C /* Resources */,
-				WIDGETEMBED /* Embed Foundation Extensions */,
+				EDF27352ADEFCA2E8F4DD6F3 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				WIDGETDEP /* PBXTargetDependency */,
+				7B5534E8B7E893AFDAAC2865 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				8873E4D12E9F61C700ACFF5C /* Usage4Claude */,
@@ -131,26 +131,26 @@
 			productReference = 8873E4CF2E9F61C700ACFF5C /* Usage4Claude.app */;
 			productType = "com.apple.product-type.application";
 		};
-		WIDGETTARGET /* Usage4ClaudeWidgetExtension */ = {
+		AC785F8C97E63874BBA3DA5A /* Usage4ClaudeWidgetExtension */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = WIDGETCFGLIST /* Build configuration list for PBXNativeTarget "Usage4ClaudeWidgetExtension" */;
+			buildConfigurationList = 33E59AEB0BA46DD3E4735F70 /* Build configuration list for PBXNativeTarget "Usage4ClaudeWidgetExtension" */;
 			buildPhases = (
-				WIDGETSRC /* Sources */,
-				WIDGETFWK /* Frameworks */,
-				WIDGETRES /* Resources */,
+				17F20B7601A9B790253FDF5D /* Sources */,
+				C7DFE2691DD0776179DE5342 /* Frameworks */,
+				B4698622C34BA37D25D24614 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				WIDGETGRP /* Usage4ClaudeWidget */,
+				E13350EACE2EC0906F5703CB /* Usage4ClaudeWidget */,
 			);
 			name = Usage4ClaudeWidgetExtension;
 			packageProductDependencies = (
 			);
 			productName = Usage4ClaudeWidgetExtension;
-			productReference = WIDGETPROD /* Usage4ClaudeWidgetExtension.appex */;
+			productReference = 068039FD2F82B5A332FAC8C7 /* Usage4ClaudeWidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
@@ -167,7 +167,7 @@
 						CreatedOnToolsVersion = 26.0.1;
 						LastSwiftMigration = 2600;
 					};
-					WIDGETTARGET = {
+					AC785F8C97E63874BBA3DA5A = {
 						CreatedOnToolsVersion = 26.0.1;
 					};
 				};
@@ -191,7 +191,7 @@
 			projectRoot = "";
 			targets = (
 				8873E4CE2E9F61C700ACFF5C /* Usage4Claude */,
-				WIDGETTARGET /* Usage4ClaudeWidgetExtension */,
+				AC785F8C97E63874BBA3DA5A /* Usage4ClaudeWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -204,7 +204,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		WIDGETRES /* Resources */ = {
+		B4698622C34BA37D25D24614 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -221,7 +221,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		WIDGETSRC /* Sources */ = {
+		17F20B7601A9B790253FDF5D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -231,10 +231,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		WIDGETDEP /* PBXTargetDependency */ = {
+		7B5534E8B7E893AFDAAC2865 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = WIDGETTARGET /* Usage4ClaudeWidgetExtension */;
-			targetProxy = WIDGETPROXY /* PBXContainerItemProxy */;
+			target = AC785F8C97E63874BBA3DA5A /* Usage4ClaudeWidgetExtension */;
+			targetProxy = 776710D32DDD1B75B1513839 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -372,14 +372,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Usage4Claude/Usage4Claude.entitlements;
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Usage4Claude-CodeSigning";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Usage4Claude-CodeSigning";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				ENABLE_APP_SANDBOX = NO;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
@@ -400,7 +400,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.fi5h.Usage4Claude;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -424,14 +424,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Usage4Claude/Usage4Claude.entitlements;
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Usage4Claude-CodeSigning";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Usage4Claude-CodeSigning";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				ENABLE_APP_SANDBOX = NO;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
@@ -452,7 +452,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 2.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.fi5h.Usage4Claude;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -468,20 +468,20 @@
 			};
 			name = Release;
 		};
-		WIDGETCFGDEBUG /* Debug */ = {
+		41C5C227479EA406FC751007 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements;
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Usage4Claude-CodeSigning";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Usage4Claude-CodeSigning";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				ENABLE_APP_SANDBOX = NO;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "";
@@ -508,20 +508,20 @@
 			};
 			name = Debug;
 		};
-		WIDGETCFGRELEASE /* Release */ = {
+		EEFAEB934F1F424994C35C21 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements;
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Usage4Claude-CodeSigning";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Usage4Claude-CodeSigning";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				ENABLE_APP_SANDBOX = NO;
+				ENABLE_APP_SANDBOX = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "";
@@ -568,11 +568,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		WIDGETCFGLIST /* Build configuration list for PBXNativeTarget "Usage4ClaudeWidgetExtension" */ = {
+		33E59AEB0BA46DD3E4735F70 /* Build configuration list for PBXNativeTarget "Usage4ClaudeWidgetExtension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				WIDGETCFGDEBUG /* Debug */,
-				WIDGETCFGRELEASE /* Release */,
+				41C5C227479EA406FC751007 /* Debug */,
+				EEFAEB934F1F424994C35C21 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Usage4Claude.xcodeproj/xcshareddata/xcschemes/Usage4Claude-Debug.xcscheme
+++ b/Usage4Claude.xcodeproj/xcshareddata/xcschemes/Usage4Claude-Debug.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2600"
+   LastUpgradeVersion = "2620"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Usage4Claude.xcodeproj/xcshareddata/xcschemes/Usage4Claude-Release.xcscheme
+++ b/Usage4Claude.xcodeproj/xcshareddata/xcschemes/Usage4Claude-Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2600"
+   LastUpgradeVersion = "2620"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Usage4Claude.xcodeproj/xcshareddata/xcschemes/Usage4Claude.xcscheme
+++ b/Usage4Claude.xcodeproj/xcshareddata/xcschemes/Usage4Claude.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2600"
+   LastUpgradeVersion = "2620"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Usage4Claude/Helpers/DataRefreshManager.swift
+++ b/Usage4Claude/Helpers/DataRefreshManager.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Combine
 import OSLog
+import WidgetKit
 
 /// 数据刷新管理器
 /// 负责管理所有数据刷新、定时器、更新检查和重置验证逻辑
@@ -105,6 +106,9 @@ class DataRefreshManager: ObservableObject {
                     if self.settings.notificationsEnabled {
                         NotificationManager.shared.checkAndNotify(usageData: data, previousData: previousData)
                     }
+
+                    // Save to App Group for widget
+                    self.syncDataToWidget(data)
 
                     // 智能模式：根据百分比变化调整刷新频率
                     self.settings.updateSmartMonitoringMode(currentUtilization: data.percentage)
@@ -423,6 +427,19 @@ class DataRefreshManager: ObservableObject {
     func checkForUpdatesManually() {
         // 手动检查更新（会弹出对话框）
         updateChecker.checkForUpdates(manually: true)
+    }
+
+    // MARK: - Widget Sync
+
+    /// Sync usage data to App Group for widget access
+    /// - Parameter data: The usage data to sync
+    private func syncDataToWidget(_ data: UsageData) {
+        let sharedData = SharedUsageData(from: data)
+        sharedData.save()
+
+        // Reload widget timeline
+        WidgetCenter.shared.reloadTimelines(ofKind: "Usage4ClaudeWidget")
+        Logger.menuBar.debug("Widget data synced and timeline reloaded")
     }
 
     // MARK: - Cleanup

--- a/Usage4Claude/Shared/SharedUsageData.swift
+++ b/Usage4Claude/Shared/SharedUsageData.swift
@@ -197,23 +197,36 @@ extension SharedUsageData {
     }
 }
 
-// MARK: - UserDefaults Storage
+// MARK: - File-based Storage (Local Development without App Groups)
 
 extension SharedUsageData {
-    private static let storageKey = "SharedUsageData"
+    private static let fileName = "SharedUsageData.json"
 
-    /// Save to App Group UserDefaults
+    /// Get shared storage URL accessible by both app and widget
+    /// Uses a file in the user's Application Support directory
+    private static var storageURL: URL? {
+        // Use a shared location in user's home directory
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser
+        let sharedDir = homeDir.appendingPathComponent(".Usage4Claude")
+
+        // Create directory if needed
+        try? FileManager.default.createDirectory(at: sharedDir, withIntermediateDirectories: true)
+
+        return sharedDir.appendingPathComponent(fileName)
+    }
+
+    /// Save to shared file
     func save() {
-        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else { return }
+        guard let url = Self.storageURL else { return }
         if let encoded = try? JSONEncoder().encode(self) {
-            defaults.set(encoded, forKey: Self.storageKey)
+            try? encoded.write(to: url)
         }
     }
 
-    /// Load from App Group UserDefaults
+    /// Load from shared file
     static func load() -> SharedUsageData? {
-        guard let defaults = UserDefaults(suiteName: appGroupIdentifier),
-              let data = defaults.data(forKey: storageKey),
+        guard let url = storageURL,
+              let data = try? Data(contentsOf: url),
               let decoded = try? JSONDecoder().decode(SharedUsageData.self, from: data) else {
             return nil
         }

--- a/Usage4Claude/Shared/SharedUsageData.swift
+++ b/Usage4Claude/Shared/SharedUsageData.swift
@@ -1,0 +1,222 @@
+//
+//  SharedUsageData.swift
+//  Usage4Claude
+//
+//  Shared data model for App Group communication between main app and widget.
+//
+
+import Foundation
+
+/// App Group identifier for sharing data between app and widget
+let appGroupIdentifier = "group.xyz.fi5h.Usage4Claude"
+
+/// Codable wrapper for sharing usage data via App Group UserDefaults
+struct SharedUsageData: Codable {
+    /// Limit type for display
+    enum LimitType: String, Codable, CaseIterable {
+        case fiveHour = "5h"
+        case sevenDay = "7d"
+        case opus = "opus"
+        case sonnet = "sonnet"
+        case extraUsage = "extra"
+
+        var displayName: String {
+            switch self {
+            case .fiveHour: return "5h"
+            case .sevenDay: return "7d"
+            case .opus: return "Opus"
+            case .sonnet: return "Sonnet"
+            case .extraUsage: return "Extra"
+            }
+        }
+
+        var iconName: String {
+            switch self {
+            case .fiveHour: return "laptopcomputer"
+            case .sevenDay: return "keyboard"
+            case .opus: return "hand.tap"
+            case .sonnet: return "circle"
+            case .extraUsage: return "dollarsign.circle"
+            }
+        }
+    }
+
+    /// Single limit data for widget display
+    struct LimitEntry: Codable, Identifiable {
+        var id: String { type.rawValue }
+        let type: LimitType
+        let percentage: Double
+        let resetsAt: Date?
+        let isAvailable: Bool
+
+        /// Formatted remaining time string (compact)
+        var formattedRemaining: String {
+            guard let resetsAt = resetsAt else { return "-" }
+            let remaining = resetsAt.timeIntervalSinceNow
+            guard remaining > 0 else { return "Soon" }
+
+            let totalMinutes = Int(ceil(remaining / 60))
+            if totalMinutes < 60 {
+                return "\(totalMinutes)m"
+            }
+
+            let totalHours = totalMinutes / 60
+            let minutes = totalMinutes % 60
+
+            if totalHours < 24 {
+                return minutes > 0 ? "\(totalHours)h\(minutes)m" : "\(totalHours)h"
+            }
+
+            let days = totalHours / 24
+            let hours = totalHours % 24
+            return hours > 0 ? "\(days)d\(hours)h" : "\(days)d"
+        }
+    }
+
+    /// Extra usage specific data
+    struct ExtraUsageEntry: Codable {
+        let enabled: Bool
+        let used: Double?
+        let limit: Double?
+        let currency: String
+
+        var percentage: Double? {
+            guard let used = used, let limit = limit, limit > 0 else { return nil }
+            return (used / limit) * 100.0
+        }
+
+        var formattedAmount: String {
+            guard enabled, let used = used, let limit = limit else { return "-" }
+            return String(format: "$%.0f/$%.0f", used, limit)
+        }
+    }
+
+    // MARK: - Properties
+
+    let fiveHour: LimitEntry?
+    let sevenDay: LimitEntry?
+    let opus: LimitEntry?
+    let sonnet: LimitEntry?
+    let extraUsage: ExtraUsageEntry?
+    let lastUpdated: Date
+    let hasError: Bool
+    let errorMessage: String?
+
+    /// Active limit entries for widget display (non-nil, available entries)
+    var activeLimits: [LimitEntry] {
+        [fiveHour, sevenDay, opus, sonnet].compactMap { $0 }.filter { $0.isAvailable }
+    }
+
+    /// Check if any data is available
+    var hasData: Bool {
+        !activeLimits.isEmpty || (extraUsage?.enabled == true)
+    }
+}
+
+// MARK: - Conversion from UsageData
+
+extension SharedUsageData {
+    /// Initialize from UsageData (main app model)
+    init(from usageData: UsageData) {
+        self.fiveHour = usageData.fiveHour.map {
+            LimitEntry(
+                type: .fiveHour,
+                percentage: $0.percentage,
+                resetsAt: $0.resetsAt,
+                isAvailable: true
+            )
+        }
+
+        self.sevenDay = usageData.sevenDay.map {
+            LimitEntry(
+                type: .sevenDay,
+                percentage: $0.percentage,
+                resetsAt: $0.resetsAt,
+                isAvailable: true
+            )
+        }
+
+        self.opus = usageData.opus.map {
+            LimitEntry(
+                type: .opus,
+                percentage: $0.percentage,
+                resetsAt: $0.resetsAt,
+                isAvailable: true
+            )
+        }
+
+        self.sonnet = usageData.sonnet.map {
+            LimitEntry(
+                type: .sonnet,
+                percentage: $0.percentage,
+                resetsAt: $0.resetsAt,
+                isAvailable: true
+            )
+        }
+
+        self.extraUsage = usageData.extraUsage.map {
+            ExtraUsageEntry(
+                enabled: $0.enabled,
+                used: $0.used,
+                limit: $0.limit,
+                currency: $0.currency
+            )
+        }
+
+        self.lastUpdated = Date()
+        self.hasError = false
+        self.errorMessage = nil
+    }
+
+    /// Create error state
+    static func error(_ message: String) -> SharedUsageData {
+        SharedUsageData(
+            fiveHour: nil,
+            sevenDay: nil,
+            opus: nil,
+            sonnet: nil,
+            extraUsage: nil,
+            lastUpdated: Date(),
+            hasError: true,
+            errorMessage: message
+        )
+    }
+
+    /// Create empty placeholder
+    static var placeholder: SharedUsageData {
+        SharedUsageData(
+            fiveHour: LimitEntry(type: .fiveHour, percentage: 77, resetsAt: Date().addingTimeInterval(3600 * 2), isAvailable: true),
+            sevenDay: LimitEntry(type: .sevenDay, percentage: 100, resetsAt: Date().addingTimeInterval(3600 * 24 * 3), isAvailable: true),
+            opus: LimitEntry(type: .opus, percentage: 71, resetsAt: Date().addingTimeInterval(3600 * 24 * 5), isAvailable: true),
+            sonnet: nil,
+            extraUsage: nil,
+            lastUpdated: Date(),
+            hasError: false,
+            errorMessage: nil
+        )
+    }
+}
+
+// MARK: - UserDefaults Storage
+
+extension SharedUsageData {
+    private static let storageKey = "SharedUsageData"
+
+    /// Save to App Group UserDefaults
+    func save() {
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else { return }
+        if let encoded = try? JSONEncoder().encode(self) {
+            defaults.set(encoded, forKey: Self.storageKey)
+        }
+    }
+
+    /// Load from App Group UserDefaults
+    static func load() -> SharedUsageData? {
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier),
+              let data = defaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode(SharedUsageData.self, from: data) else {
+            return nil
+        }
+        return decoded
+    }
+}

--- a/Usage4Claude/Shared/SharedUsageData.swift
+++ b/Usage4Claude/Shared/SharedUsageData.swift
@@ -197,36 +197,23 @@ extension SharedUsageData {
     }
 }
 
-// MARK: - File-based Storage (Local Development without App Groups)
+// MARK: - App Group Storage
 
 extension SharedUsageData {
-    private static let fileName = "SharedUsageData.json"
+    private static let userDefaultsKey = "SharedUsageData"
 
-    /// Get shared storage URL accessible by both app and widget
-    /// Uses a file in the user's Application Support directory
-    private static var storageURL: URL? {
-        // Use a shared location in user's home directory
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
-        let sharedDir = homeDir.appendingPathComponent(".Usage4Claude")
-
-        // Create directory if needed
-        try? FileManager.default.createDirectory(at: sharedDir, withIntermediateDirectories: true)
-
-        return sharedDir.appendingPathComponent(fileName)
-    }
-
-    /// Save to shared file
+    /// Save to App Group UserDefaults
     func save() {
-        guard let url = Self.storageURL else { return }
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else { return }
         if let encoded = try? JSONEncoder().encode(self) {
-            try? encoded.write(to: url)
+            defaults.set(encoded, forKey: Self.userDefaultsKey)
         }
     }
 
-    /// Load from shared file
+    /// Load from App Group UserDefaults
     static func load() -> SharedUsageData? {
-        guard let url = storageURL,
-              let data = try? Data(contentsOf: url),
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier),
+              let data = defaults.data(forKey: userDefaultsKey),
               let decoded = try? JSONDecoder().decode(SharedUsageData.self, from: data) else {
             return nil
         }

--- a/Usage4Claude/Usage4Claude.entitlements
+++ b/Usage4Claude/Usage4Claude.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.xyz.fi5h.Usage4Claude</string>
+	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
+</plist>

--- a/Usage4Claude/Usage4Claude.entitlements
+++ b/Usage4Claude/Usage4Claude.entitlements
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.xyz.fi5h.Usage4Claude</string>
-	</array>
-	<key>com.apple.security.network.client</key>
-	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 </dict>

--- a/Usage4Claude/Usage4Claude.entitlements
+++ b/Usage4Claude/Usage4Claude.entitlements
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.xyz.fi5h.Usage4Claude</string>
+	</array>
 </dict>
 </plist>

--- a/Usage4ClaudeWidget/SharedUsageData.swift
+++ b/Usage4ClaudeWidget/SharedUsageData.swift
@@ -1,0 +1,167 @@
+//
+//  SharedUsageData.swift
+//  Usage4ClaudeWidget
+//
+//  Shared data model for App Group communication between main app and widget.
+//  Widget-only version without UsageData dependency.
+//
+
+import Foundation
+
+/// App Group identifier for sharing data between app and widget
+let appGroupIdentifier = "group.xyz.fi5h.Usage4Claude"
+
+/// Codable wrapper for sharing usage data via App Group UserDefaults
+struct SharedUsageData: Codable {
+    /// Limit type for display
+    enum LimitType: String, Codable, CaseIterable {
+        case fiveHour = "5h"
+        case sevenDay = "7d"
+        case opus = "opus"
+        case sonnet = "sonnet"
+        case extraUsage = "extra"
+
+        var displayName: String {
+            switch self {
+            case .fiveHour: return "5h"
+            case .sevenDay: return "7d"
+            case .opus: return "Opus"
+            case .sonnet: return "Sonnet"
+            case .extraUsage: return "Extra"
+            }
+        }
+
+        var iconName: String {
+            switch self {
+            case .fiveHour: return "laptopcomputer"
+            case .sevenDay: return "keyboard"
+            case .opus: return "hand.tap"
+            case .sonnet: return "circle"
+            case .extraUsage: return "dollarsign.circle"
+            }
+        }
+    }
+
+    /// Single limit data for widget display
+    struct LimitEntry: Codable, Identifiable {
+        var id: String { type.rawValue }
+        let type: LimitType
+        let percentage: Double
+        let resetsAt: Date?
+        let isAvailable: Bool
+
+        /// Formatted remaining time string (compact)
+        var formattedRemaining: String {
+            guard let resetsAt = resetsAt else { return "-" }
+            let remaining = resetsAt.timeIntervalSinceNow
+            guard remaining > 0 else { return "Soon" }
+
+            let totalMinutes = Int(ceil(remaining / 60))
+            if totalMinutes < 60 {
+                return "\(totalMinutes)m"
+            }
+
+            let totalHours = totalMinutes / 60
+            let minutes = totalMinutes % 60
+
+            if totalHours < 24 {
+                return minutes > 0 ? "\(totalHours)h\(minutes)m" : "\(totalHours)h"
+            }
+
+            let days = totalHours / 24
+            let hours = totalHours % 24
+            return hours > 0 ? "\(days)d\(hours)h" : "\(days)d"
+        }
+    }
+
+    /// Extra usage specific data
+    struct ExtraUsageEntry: Codable {
+        let enabled: Bool
+        let used: Double?
+        let limit: Double?
+        let currency: String
+
+        var percentage: Double? {
+            guard let used = used, let limit = limit, limit > 0 else { return nil }
+            return (used / limit) * 100.0
+        }
+
+        var formattedAmount: String {
+            guard enabled, let used = used, let limit = limit else { return "-" }
+            return String(format: "$%.0f/$%.0f", used, limit)
+        }
+    }
+
+    // MARK: - Properties
+
+    let fiveHour: LimitEntry?
+    let sevenDay: LimitEntry?
+    let opus: LimitEntry?
+    let sonnet: LimitEntry?
+    let extraUsage: ExtraUsageEntry?
+    let lastUpdated: Date
+    let hasError: Bool
+    let errorMessage: String?
+
+    /// Active limit entries for widget display (non-nil, available entries)
+    var activeLimits: [LimitEntry] {
+        [fiveHour, sevenDay, opus, sonnet].compactMap { $0 }.filter { $0.isAvailable }
+    }
+
+    /// Check if any data is available
+    var hasData: Bool {
+        !activeLimits.isEmpty || (extraUsage?.enabled == true)
+    }
+
+    /// Create error state
+    static func error(_ message: String) -> SharedUsageData {
+        SharedUsageData(
+            fiveHour: nil,
+            sevenDay: nil,
+            opus: nil,
+            sonnet: nil,
+            extraUsage: nil,
+            lastUpdated: Date(),
+            hasError: true,
+            errorMessage: message
+        )
+    }
+
+    /// Create empty placeholder
+    static var placeholder: SharedUsageData {
+        SharedUsageData(
+            fiveHour: LimitEntry(type: .fiveHour, percentage: 77, resetsAt: Date().addingTimeInterval(3600 * 2), isAvailable: true),
+            sevenDay: LimitEntry(type: .sevenDay, percentage: 100, resetsAt: Date().addingTimeInterval(3600 * 24 * 3), isAvailable: true),
+            opus: LimitEntry(type: .opus, percentage: 71, resetsAt: Date().addingTimeInterval(3600 * 24 * 5), isAvailable: true),
+            sonnet: nil,
+            extraUsage: nil,
+            lastUpdated: Date(),
+            hasError: false,
+            errorMessage: nil
+        )
+    }
+}
+
+// MARK: - UserDefaults Storage
+
+extension SharedUsageData {
+    private static let storageKey = "SharedUsageData"
+
+    /// Save to App Group UserDefaults
+    func save() {
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else { return }
+        if let encoded = try? JSONEncoder().encode(self) {
+            defaults.set(encoded, forKey: Self.storageKey)
+        }
+    }
+
+    /// Load from App Group UserDefaults
+    static func load() -> SharedUsageData? {
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier),
+              let data = defaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode(SharedUsageData.self, from: data) else {
+            return nil
+        }
+        return decoded
+    }
+}

--- a/Usage4ClaudeWidget/SharedUsageData.swift
+++ b/Usage4ClaudeWidget/SharedUsageData.swift
@@ -142,36 +142,23 @@ struct SharedUsageData: Codable {
     }
 }
 
-// MARK: - File-based Storage (Local Development without App Groups)
+// MARK: - App Group Storage
 
 extension SharedUsageData {
-    private static let fileName = "SharedUsageData.json"
+    private static let userDefaultsKey = "SharedUsageData"
 
-    /// Get shared storage URL accessible by both app and widget
-    /// Uses a file in the user's home directory
-    private static var storageURL: URL? {
-        // Use a shared location in user's home directory
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
-        let sharedDir = homeDir.appendingPathComponent(".Usage4Claude")
-
-        // Create directory if needed
-        try? FileManager.default.createDirectory(at: sharedDir, withIntermediateDirectories: true)
-
-        return sharedDir.appendingPathComponent(fileName)
-    }
-
-    /// Save to shared file
+    /// Save to App Group UserDefaults
     func save() {
-        guard let url = Self.storageURL else { return }
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else { return }
         if let encoded = try? JSONEncoder().encode(self) {
-            try? encoded.write(to: url)
+            defaults.set(encoded, forKey: Self.userDefaultsKey)
         }
     }
 
-    /// Load from shared file
+    /// Load from App Group UserDefaults
     static func load() -> SharedUsageData? {
-        guard let url = storageURL,
-              let data = try? Data(contentsOf: url),
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier),
+              let data = defaults.data(forKey: userDefaultsKey),
               let decoded = try? JSONDecoder().decode(SharedUsageData.self, from: data) else {
             return nil
         }

--- a/Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements
+++ b/Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.xyz.fi5h.Usage4Claude</string>
+	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements
+++ b/Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.xyz.fi5h.Usage4Claude</string>
-	</array>
-	<key>com.apple.security.network.client</key>
-	<true/>
-</dict>
+<dict/>
 </plist>

--- a/Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements
+++ b/Usage4ClaudeWidget/Usage4ClaudeWidget.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.xyz.fi5h.Usage4Claude</string>
+	</array>
+</dict>
 </plist>

--- a/Usage4ClaudeWidget/Usage4ClaudeWidget.swift
+++ b/Usage4ClaudeWidget/Usage4ClaudeWidget.swift
@@ -49,7 +49,7 @@ struct Usage4ClaudeWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: UsageProvider()) { entry in
             UsageWidgetEntryView(entry: entry)
-                .containerBackground(.black, for: .widget)
+                .containerBackground(Color(.widgetBackground), for: .widget)
         }
         .configurationDisplayName("Claude Usage")
         .description("Monitor your Claude.ai usage limits.")
@@ -80,23 +80,32 @@ struct UsageWidgetEntryView: View {
 
 struct SmallWidgetView: View {
     let data: SharedUsageData
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         if data.hasError {
             ErrorView(message: data.errorMessage ?? "Error")
         } else if !data.hasData {
             NoDataView()
-        } else {
-            // Show up to 2 rings in small widget
-            let limits = Array(data.activeLimits.prefix(2))
-            VStack(spacing: 8) {
-                HStack(spacing: 12) {
-                    ForEach(limits) { limit in
-                        UsageRingView(limit: limit, size: 60)
-                    }
+        } else if let fiveHour = data.fiveHour {
+            // Show only 5h ring in small widget
+            VStack(spacing: 4) {
+                UsageRingView(limit: fiveHour, size: 70)
+                Text("\(Int(fiveHour.percentage))%")
+                    .font(.system(size: 16, weight: .medium, design: .rounded))
+                    .foregroundColor(colorScheme == .dark ? .white : .black)
+                // Reset time
+                HStack(spacing: 2) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 10))
+                    Text(fiveHour.formattedRemaining)
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
                 }
+                .foregroundColor(.secondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            NoDataView()
         }
     }
 }
@@ -112,15 +121,11 @@ struct MediumWidgetView: View {
         } else if !data.hasData {
             NoDataView()
         } else {
-            // Show up to 4 rings like the screenshot
-            let limits = Array(data.activeLimits.prefix(4))
+            // Show up to 3 rings (5h, 7d, Sonnet)
+            let limits = Array(data.activeLimits.prefix(3))
             HStack(spacing: 0) {
-                ForEach(0..<4, id: \.self) { index in
-                    if index < limits.count {
-                        UsageRingItemView(limit: limits[index])
-                    } else {
-                        EmptyRingItemView()
-                    }
+                ForEach(limits) { limit in
+                    UsageRingItemView(limit: limit)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -133,14 +138,24 @@ struct MediumWidgetView: View {
 
 struct UsageRingItemView: View {
     let limit: SharedUsageData.LimitEntry
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
-        VStack(spacing: 8) {
-            UsageRingView(limit: limit, size: 70)
+        VStack(spacing: 4) {
+            UsageRingView(limit: limit, size: 60)
 
             Text("\(Int(limit.percentage))%")
-                .font(.system(size: 16, weight: .medium, design: .rounded))
-                .foregroundColor(.white)
+                .font(.system(size: 14, weight: .medium, design: .rounded))
+                .foregroundColor(colorScheme == .dark ? .white : .black)
+
+            // Reset time
+            HStack(spacing: 2) {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 9))
+                Text(limit.formattedRemaining)
+                    .font(.system(size: 10, weight: .medium, design: .rounded))
+            }
+            .foregroundColor(.secondary)
         }
         .frame(maxWidth: .infinity)
     }
@@ -170,6 +185,7 @@ struct EmptyRingItemView: View {
 struct UsageRingView: View {
     let limit: SharedUsageData.LimitEntry
     let size: CGFloat
+    @Environment(\.colorScheme) var colorScheme
 
     private var ringColor: Color {
         WidgetColorScheme.color(for: limit.type, percentage: limit.percentage)
@@ -179,11 +195,20 @@ struct UsageRingView: View {
         min(1.0, max(0.0, limit.percentage / 100.0))
     }
 
+    /// Text label for center of ring
+    private var centerLabel: String {
+        switch limit.type {
+        case .fiveHour: return "5h"
+        case .sevenDay: return "7d"
+        case .sonnet: return "S"
+        }
+    }
+
     var body: some View {
         ZStack {
             // Background ring
             Circle()
-                .stroke(ringColor.opacity(0.2), lineWidth: size * 0.12)
+                .stroke(ringColor.opacity(colorScheme == .dark ? 0.2 : 0.3), lineWidth: size * 0.12)
 
             // Progress ring
             Circle()
@@ -197,10 +222,10 @@ struct UsageRingView: View {
                 )
                 .rotationEffect(.degrees(-90))
 
-            // Center icon
-            Image(systemName: limit.type.iconName)
-                .font(.system(size: size * 0.3, weight: .medium))
-                .foregroundColor(.gray)
+            // Center text label
+            Text(centerLabel)
+                .font(.system(size: size * 0.28, weight: .semibold, design: .rounded))
+                .foregroundColor(.secondary)
         }
         .frame(width: size, height: size)
     }
@@ -245,6 +270,7 @@ struct NoDataView: View {
 }
 
 // MARK: - Widget Color Scheme
+// Colors match UsageColorScheme in the main app (ColorScheme.swift)
 
 enum WidgetColorScheme {
     /// Get color for limit type and percentage
@@ -254,19 +280,15 @@ enum WidgetColorScheme {
             return fiveHourColor(percentage)
         case .sevenDay:
             return sevenDayColor(percentage)
-        case .opus:
-            return opusColor(percentage)
         case .sonnet:
             return sonnetColor(percentage)
-        case .extraUsage:
-            return extraUsageColor(percentage)
         }
     }
 
-    // 5-Hour: Green → Orange → Red
+    // 5-Hour: Green → Orange → Red (matches UsageColorScheme.fiveHourColorSwiftUI)
     private static func fiveHourColor(_ percentage: Double) -> Color {
         if percentage < 70 {
-            return Color(red: 40/255.0, green: 180/255.0, blue: 70/255.0) // Green #28B446
+            return .green  // System green
         } else if percentage < 90 {
             return .orange
         } else {
@@ -274,7 +296,7 @@ enum WidgetColorScheme {
         }
     }
 
-    // 7-Day: Light Purple → Deep Purple → Deep Magenta
+    // 7-Day: Light Purple → Deep Purple → Deep Magenta (matches UsageColorScheme.sevenDayColorSwiftUI)
     private static func sevenDayColor(_ percentage: Double) -> Color {
         if percentage < 70 {
             return Color(red: 192/255.0, green: 132/255.0, blue: 252/255.0) // #C084FC
@@ -285,18 +307,7 @@ enum WidgetColorScheme {
         }
     }
 
-    // Opus: Amber → Orange → Orange-Red
-    private static func opusColor(_ percentage: Double) -> Color {
-        if percentage < 70 {
-            return Color(red: 251/255.0, green: 191/255.0, blue: 36/255.0)  // #FBBF24
-        } else if percentage < 90 {
-            return .orange
-        } else {
-            return Color(red: 255/255.0, green: 100/255.0, blue: 50/255.0)  // #FF6432
-        }
-    }
-
-    // Sonnet: Light Blue → Blue → Indigo
+    // Sonnet: Light Blue → Blue → Indigo (matches UsageColorScheme.sonnetWeeklyColor)
     private static func sonnetColor(_ percentage: Double) -> Color {
         if percentage < 70 {
             return Color(red: 100/255.0, green: 200/255.0, blue: 255/255.0) // #64C8FF
@@ -307,14 +318,26 @@ enum WidgetColorScheme {
         }
     }
 
-    // Extra Usage: Pink → Magenta → Purple
-    private static func extraUsageColor(_ percentage: Double) -> Color {
-        if percentage < 70 {
-            return Color(red: 255/255.0, green: 158/255.0, blue: 205/255.0) // #FF9ECD
-        } else if percentage < 90 {
-            return Color(red: 236/255.0, green: 72/255.0, blue: 153/255.0)  // #EC4899
-        } else {
-            return Color(red: 217/255.0, green: 70/255.0, blue: 239/255.0)  // #D946EF
+}
+
+// MARK: - Widget Background Color
+
+extension ShapeStyle where Self == Color {
+    /// Adaptive widget background color
+    static var widgetBackground: Color {
+        Color(nsColor: .widgetBackground)
+    }
+}
+
+extension NSColor {
+    /// Widget background that adapts to light/dark mode
+    static var widgetBackground: NSColor {
+        NSColor(name: nil) { appearance in
+            if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+                return NSColor.black
+            } else {
+                return NSColor.white
+            }
         }
     }
 }

--- a/Usage4ClaudeWidget/Usage4ClaudeWidget.swift
+++ b/Usage4ClaudeWidget/Usage4ClaudeWidget.swift
@@ -1,0 +1,334 @@
+//
+//  Usage4ClaudeWidget.swift
+//  Usage4ClaudeWidget
+//
+//  WidgetKit widget for displaying Claude usage data.
+//
+
+import WidgetKit
+import SwiftUI
+
+// MARK: - Timeline Provider
+
+struct UsageProvider: TimelineProvider {
+    func placeholder(in context: Context) -> UsageEntry {
+        UsageEntry(date: Date(), data: .placeholder)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (UsageEntry) -> Void) {
+        let data = SharedUsageData.load() ?? .placeholder
+        completion(UsageEntry(date: Date(), data: data))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<UsageEntry>) -> Void) {
+        let data = SharedUsageData.load() ?? SharedUsageData.error("No data available. Open the app to configure.")
+
+        let currentDate = Date()
+        let entry = UsageEntry(date: currentDate, data: data)
+
+        // Refresh every 15 minutes
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: currentDate)!
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+
+        completion(timeline)
+    }
+}
+
+// MARK: - Timeline Entry
+
+struct UsageEntry: TimelineEntry {
+    let date: Date
+    let data: SharedUsageData
+}
+
+// MARK: - Widget Definition
+
+struct Usage4ClaudeWidget: Widget {
+    let kind: String = "Usage4ClaudeWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: UsageProvider()) { entry in
+            UsageWidgetEntryView(entry: entry)
+                .containerBackground(.black, for: .widget)
+        }
+        .configurationDisplayName("Claude Usage")
+        .description("Monitor your Claude.ai usage limits.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Widget Entry View
+
+struct UsageWidgetEntryView: View {
+    var entry: UsageEntry
+
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            SmallWidgetView(data: entry.data)
+        case .systemMedium:
+            MediumWidgetView(data: entry.data)
+        default:
+            SmallWidgetView(data: entry.data)
+        }
+    }
+}
+
+// MARK: - Small Widget View
+
+struct SmallWidgetView: View {
+    let data: SharedUsageData
+
+    var body: some View {
+        if data.hasError {
+            ErrorView(message: data.errorMessage ?? "Error")
+        } else if !data.hasData {
+            NoDataView()
+        } else {
+            // Show up to 2 rings in small widget
+            let limits = Array(data.activeLimits.prefix(2))
+            VStack(spacing: 8) {
+                HStack(spacing: 12) {
+                    ForEach(limits) { limit in
+                        UsageRingView(limit: limit, size: 60)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+// MARK: - Medium Widget View (Apple Style - Screenshot Match)
+
+struct MediumWidgetView: View {
+    let data: SharedUsageData
+
+    var body: some View {
+        if data.hasError {
+            ErrorView(message: data.errorMessage ?? "Error")
+        } else if !data.hasData {
+            NoDataView()
+        } else {
+            // Show up to 4 rings like the screenshot
+            let limits = Array(data.activeLimits.prefix(4))
+            HStack(spacing: 0) {
+                ForEach(0..<4, id: \.self) { index in
+                    if index < limits.count {
+                        UsageRingItemView(limit: limits[index])
+                    } else {
+                        EmptyRingItemView()
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, 8)
+        }
+    }
+}
+
+// MARK: - Usage Ring Item View (with label)
+
+struct UsageRingItemView: View {
+    let limit: SharedUsageData.LimitEntry
+
+    var body: some View {
+        VStack(spacing: 8) {
+            UsageRingView(limit: limit, size: 70)
+
+            Text("\(Int(limit.percentage))%")
+                .font(.system(size: 16, weight: .medium, design: .rounded))
+                .foregroundColor(.white)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Empty Ring Item View
+
+struct EmptyRingItemView: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 8)
+                    .frame(width: 70, height: 70)
+            }
+
+            Text("-")
+                .font(.system(size: 16, weight: .medium, design: .rounded))
+                .foregroundColor(.gray.opacity(0.5))
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Usage Ring View
+
+struct UsageRingView: View {
+    let limit: SharedUsageData.LimitEntry
+    let size: CGFloat
+
+    private var ringColor: Color {
+        WidgetColorScheme.color(for: limit.type, percentage: limit.percentage)
+    }
+
+    private var progress: Double {
+        min(1.0, max(0.0, limit.percentage / 100.0))
+    }
+
+    var body: some View {
+        ZStack {
+            // Background ring
+            Circle()
+                .stroke(ringColor.opacity(0.2), lineWidth: size * 0.12)
+
+            // Progress ring
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    ringColor,
+                    style: StrokeStyle(
+                        lineWidth: size * 0.12,
+                        lineCap: .round
+                    )
+                )
+                .rotationEffect(.degrees(-90))
+
+            // Center icon
+            Image(systemName: limit.type.iconName)
+                .font(.system(size: size * 0.3, weight: .medium))
+                .foregroundColor(.gray)
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+// MARK: - Error View
+
+struct ErrorView: View {
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.title2)
+                .foregroundColor(.orange)
+
+            Text(message)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+        }
+        .padding()
+    }
+}
+
+// MARK: - No Data View
+
+struct NoDataView: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "arrow.clockwise")
+                .font(.title2)
+                .foregroundColor(.secondary)
+
+            Text("Open app to sync")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+    }
+}
+
+// MARK: - Widget Color Scheme
+
+enum WidgetColorScheme {
+    /// Get color for limit type and percentage
+    static func color(for type: SharedUsageData.LimitType, percentage: Double) -> Color {
+        switch type {
+        case .fiveHour:
+            return fiveHourColor(percentage)
+        case .sevenDay:
+            return sevenDayColor(percentage)
+        case .opus:
+            return opusColor(percentage)
+        case .sonnet:
+            return sonnetColor(percentage)
+        case .extraUsage:
+            return extraUsageColor(percentage)
+        }
+    }
+
+    // 5-Hour: Green → Orange → Red
+    private static func fiveHourColor(_ percentage: Double) -> Color {
+        if percentage < 70 {
+            return Color(red: 40/255.0, green: 180/255.0, blue: 70/255.0) // Green #28B446
+        } else if percentage < 90 {
+            return .orange
+        } else {
+            return .red
+        }
+    }
+
+    // 7-Day: Light Purple → Deep Purple → Deep Magenta
+    private static func sevenDayColor(_ percentage: Double) -> Color {
+        if percentage < 70 {
+            return Color(red: 192/255.0, green: 132/255.0, blue: 252/255.0) // #C084FC
+        } else if percentage < 90 {
+            return Color(red: 180/255.0, green: 80/255.0, blue: 240/255.0)  // #B450F0
+        } else {
+            return Color(red: 180/255.0, green: 30/255.0, blue: 160/255.0)  // #B41EA0
+        }
+    }
+
+    // Opus: Amber → Orange → Orange-Red
+    private static func opusColor(_ percentage: Double) -> Color {
+        if percentage < 70 {
+            return Color(red: 251/255.0, green: 191/255.0, blue: 36/255.0)  // #FBBF24
+        } else if percentage < 90 {
+            return .orange
+        } else {
+            return Color(red: 255/255.0, green: 100/255.0, blue: 50/255.0)  // #FF6432
+        }
+    }
+
+    // Sonnet: Light Blue → Blue → Indigo
+    private static func sonnetColor(_ percentage: Double) -> Color {
+        if percentage < 70 {
+            return Color(red: 100/255.0, green: 200/255.0, blue: 255/255.0) // #64C8FF
+        } else if percentage < 90 {
+            return .blue
+        } else {
+            return Color(red: 79/255.0, green: 70/255.0, blue: 229/255.0)   // #4F46E5
+        }
+    }
+
+    // Extra Usage: Pink → Magenta → Purple
+    private static func extraUsageColor(_ percentage: Double) -> Color {
+        if percentage < 70 {
+            return Color(red: 255/255.0, green: 158/255.0, blue: 205/255.0) // #FF9ECD
+        } else if percentage < 90 {
+            return Color(red: 236/255.0, green: 72/255.0, blue: 153/255.0)  // #EC4899
+        } else {
+            return Color(red: 217/255.0, green: 70/255.0, blue: 239/255.0)  // #D946EF
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview(as: .systemSmall) {
+    Usage4ClaudeWidget()
+} timeline: {
+    UsageEntry(date: .now, data: .placeholder)
+}
+
+#Preview(as: .systemMedium) {
+    Usage4ClaudeWidget()
+} timeline: {
+    UsageEntry(date: .now, data: .placeholder)
+}

--- a/Usage4ClaudeWidget/Usage4ClaudeWidgetBundle.swift
+++ b/Usage4ClaudeWidget/Usage4ClaudeWidgetBundle.swift
@@ -1,0 +1,16 @@
+//
+//  Usage4ClaudeWidgetBundle.swift
+//  Usage4ClaudeWidget
+//
+//  Widget extension bundle for Usage4Claude.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct Usage4ClaudeWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        Usage4ClaudeWidget()
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a native macOS WidgetKit widget extension that displays Claude usage data with Apple-style circular progress rings.

## Features

- **Small Widget**: Shows 5-hour limit with percentage and reset time
- **Medium Widget**: Shows up to 3 usage rings (5h, 7d, Sonnet) with percentages and reset times
- **Apple-style Design**: Circular progress rings with text labels in center
- **Dark/Light Theme Support**: Adaptive background and colors for both themes
- **Color-coded Progress**: Matches main app's color scheme
- **Auto-refresh**: Widget updates every 15 minutes

## Widget Display

| Limit Type | Center Label | Color Scheme |
|------------|--------------|--------------|
| 5-Hour | `5h` | Green → Orange → Red |
| 7-Day | `7d` | Light Purple → Deep Purple → Magenta |
| Sonnet | `S` | Light Blue → Blue → Indigo |

## Technical Details

### New Files
- `Usage4ClaudeWidget/` - Widget extension target
  - `Usage4ClaudeWidget.swift` - Main widget with TimelineProvider and views
  - `Usage4ClaudeWidgetBundle.swift` - Widget bundle entry point
  - `Usage4ClaudeWidget.entitlements` - Widget entitlements (App Group)
  - `SharedUsageData.swift` - Widget-only data model

### Data Sharing
- Uses **App Groups** (`group.xyz.fi5h.Usage4Claude`) via `UserDefaults(suiteName:)` for sandbox-safe data sharing between app and widget
- Main app writes data on refresh, widget reads on timeline update

### Modified Files
- `Usage4Claude/Shared/SharedUsageData.swift` - Shared data model with App Group storage
- `Usage4Claude/Usage4Claude.entitlements` - Added App Group entitlement
- `Usage4Claude/Helpers/DataRefreshManager.swift` - Widget sync on data refresh
- `project.pbxproj` - Added Widget extension target (Xcode-style UUIDs)

### Signing & Sandbox
- Main app signing config unchanged (Manual, Usage4Claude-CodeSigning, sandbox enabled)
- Widget extension uses same signing style
- Both targets have `ENABLE_APP_SANDBOX = YES`

### Deployment Target
- Both main app and widget target **macOS 14.0** (WidgetKit requires macOS 14.0+)
- Note: This is a bump from the previous 13.0 — required for WidgetKit APIs

## Test Plan

- [x] Build and run main app
- [x] Verify widget appears in widget gallery (requires signing)
- [x] Add Small widget to desktop - shows 5h ring with % and reset time
- [x] Add Medium widget to desktop - shows 3 rings with % and reset times
- [x] Verify data syncs from main app to widget via App Group
- [ ] Verify colors match main app's color scheme
- [ ] Test Dark and Light theme appearance
- [ ] Verify widget refreshes automatically