### PR TITLE
Fix extra usage amounts always displaying $ regardless of currency

### DIFF
--- a/Usage4Claude/Helpers/LocalizationHelper.swift
+++ b/Usage4Claude/Helpers/LocalizationHelper.swift
@@ -394,11 +394,11 @@ enum L {
     // MARK: - Extra Usage
     enum ExtraUsage {
         static var notEnabled: String { localized("extra_usage.not_enabled") }
-        static func usageAmount(_ used: Double, _ limit: Double) -> String {
-            String(format: localized("extra_usage.usage_amount"), used, limit)
+        static func usageAmount(_ used: Double, _ limit: Double, symbol: String = "$") -> String {
+            String(format: localized("extra_usage.usage_amount"), symbol, used, symbol, limit)
         }
-        static func remainingAmount(_ remaining: Double) -> String {
-            String(format: localized("extra_usage.remaining_amount"), remaining)
+        static func remainingAmount(_ remaining: Double, symbol: String = "$") -> String {
+            String(format: localized("extra_usage.remaining_amount"), symbol, remaining)
         }
     }
 

--- a/Usage4Claude/Resources/en.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/en.lproj/Localizable.strings
@@ -334,8 +334,8 @@
 
 // MARK: - Extra Usage
 "extra_usage.not_enabled" = "Not Enabled";
-"extra_usage.usage_amount" = "$%.0f/$%.0f";
-"extra_usage.remaining_amount" = "$%.0f remaining";
+"extra_usage.usage_amount" = "%@%.0f/%@%.0f";
+"extra_usage.remaining_amount" = "%@%.0f remaining";
 
 // MARK: - Loading Animation
 "loading_animation.rainbow" = "Rainbow Gradient";

--- a/Usage4Claude/Resources/ja.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ja.lproj/Localizable.strings
@@ -333,8 +333,8 @@
 
 // MARK: - Extra Usage
 "extra_usage.not_enabled" = "未有効";
-"extra_usage.usage_amount" = "$%.0f/$%.0f";
-"extra_usage.remaining_amount" = "残り$%.0f";
+"extra_usage.usage_amount" = "%@%.0f/%@%.0f";
+"extra_usage.remaining_amount" = "残り%@%.0f";
 
 // MARK: - Loading Animation
 "loading_animation.rainbow" = "レインボーグラデーション";

--- a/Usage4Claude/Resources/ko.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ko.lproj/Localizable.strings
@@ -332,8 +332,8 @@
 
 // MARK: - Extra Usage
 "extra_usage.not_enabled" = "활성화되지 않음";
-"extra_usage.usage_amount" = "$%.0f/$%.0f";
-"extra_usage.remaining_amount" = "$%.0f 더 사용 가능";
+"extra_usage.usage_amount" = "%@%.0f/%@%.0f";
+"extra_usage.remaining_amount" = "%@%.0f 더 사용 가능";
 
 // MARK: - Loading Animation
 "loading_animation.rainbow" = "무지개 그라데이션";

--- a/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
@@ -332,8 +332,8 @@
 
 // MARK: - Extra Usage
 "extra_usage.not_enabled" = "未启用";
-"extra_usage.usage_amount" = "$%.0f/$%.0f";
-"extra_usage.remaining_amount" = "还可使用 $%.0f";
+"extra_usage.usage_amount" = "%@%.0f/%@%.0f";
+"extra_usage.remaining_amount" = "还可使用 %@%.0f";
 
 // MARK: - Loading Animation
 "loading_animation.rainbow" = "彩虹渐变";

--- a/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
@@ -333,8 +333,8 @@
 
 // MARK: - Extra Usage
 "extra_usage.not_enabled" = "未啟用";
-"extra_usage.usage_amount" = "$%.0f/$%.0f";
-"extra_usage.remaining_amount" = "還可使用 $%.0f";
+"extra_usage.usage_amount" = "%@%.0f/%@%.0f";
+"extra_usage.remaining_amount" = "還可使用 %@%.0f";
 
 // MARK: - Loading Animation
 "loading_animation.rainbow" = "彩虹漸變";

--- a/Usage4Claude/Services/ClaudeAPIService.swift
+++ b/Usage4Claude/Services/ClaudeAPIService.swift
@@ -939,13 +939,21 @@ struct ExtraUsageData: Sendable {
 
     // MARK: - Formatting Methods
 
+    var currencySymbol: String {
+        switch currency {
+        case "EUR": return "€"
+        case "GBP": return "£"
+        default: return "$"
+        }
+    }
+
     /// 格式化的使用金额/总额度字符串（默认模式）
     /// - Returns: 如 "$12.50 / $50.00"
     var formattedUsageAmount: String {
         guard enabled, let used = used, let limit = limit else {
             return L.ExtraUsage.notEnabled
         }
-        return L.ExtraUsage.usageAmount(used, limit)
+        return L.ExtraUsage.usageAmount(used, limit, symbol: currencySymbol)
     }
 
     /// 格式化的剩余金额字符串（剩余模式）
@@ -955,7 +963,7 @@ struct ExtraUsageData: Sendable {
             return L.ExtraUsage.notEnabled
         }
         let remaining = max(0, limit - used)
-        return L.ExtraUsage.remainingAmount(remaining)
+        return L.ExtraUsage.remainingAmount(remaining, symbol: currencySymbol)
     }
 
     /// 极简格式化的使用金额（用于列表显示）
@@ -964,7 +972,8 @@ struct ExtraUsageData: Sendable {
         guard enabled, let used = used, let limit = limit else {
             return "-"
         }
-        return String(format: "$%.0f/$%.0f", used, limit)
+        let sym = currencySymbol
+        return String(format: "%@%.0f/%@%.0f", sym, used, sym, limit)
     }
 }
 


### PR DESCRIPTION
## Problem

`ExtraUsageData` correctly stores the `currency` field from the API response (can be `USD`, `EUR`, `GBP`), but all three formatting methods hardcoded the `$` symbol, so EUR and GBP users always saw dollar signs.

Fixes #38.

## Root cause

Three places all ignored `self.currency`:

- `formattedCompactAmount`: `String(format: "$%.0f/$%.0f", used, limit)`
- `formattedUsageAmount` / `formattedRemainingAmount`: delegated to `L.ExtraUsage` localization strings which also hardcoded `$`

## Changes

- Add `currencySymbol: String` computed property to `ExtraUsageData` that maps `EUR` → `€`, `GBP` → `£`, everything else → `$`
- Update all three formatting methods to use `currencySymbol`
- Update `L.ExtraUsage.usageAmount` and `L.ExtraUsage.remainingAmount` to accept a `symbol` parameter (defaults to `$` for backward compatibility)
- Update format strings in all 5 locales (en, ja, ko, zh-Hans, zh-Hant) from `$%.0f` to `%@%.0f`