### PR TITLE
fix: prevent menu-bar icon crash on macOS 13 (NSImage hints bridging)

### DIFF
--- a/Usage4Claude/Helpers/ImageHelper.swift
+++ b/Usage4Claude/Helpers/ImageHelper.swift
@@ -70,7 +70,7 @@ enum ImageHelper {
             operation: .sourceOver,
             fraction: 1.0,
             respectFlipped: false,
-            hints: [.interpolation: NSImageInterpolation.high]
+            hints: [.interpolation: NSNumber(value: NSImageInterpolation.high.rawValue)]
         )
         image.unlockFocus()
         image.isTemplate = isTemplate


### PR DESCRIPTION
## Summary

Fixes a 100% reproducible crash on **macOS 13.7.x (Ventura)** in v3.1.0. Every data refresh that touches the menu-bar icon takes the app down with `SIGABRT`. macOS 14+ is unaffected because AppKit silently tolerates the bug there.

## Root cause

`Usage4Claude/Helpers/ImageHelper.swift:73` passed a raw Swift enum into the `hints:` dictionary of `NSImage.draw(...)`:

```swift
hints: [.interpolation: NSImageInterpolation.high]
```

`NSImage.draw(...hints:)` expects each value to be an Objective-C object. `NSImageInterpolation` is a Swift `RawRepresentable` enum and bridges as `__SwiftValue`, not `NSNumber`. AppKit on macOS 13 reads the hint via `-[NSNumber unsignedIntegerValue]`, which `__SwiftValue` doesn't implement, so `objc_msgSend` throws `NSInvalidArgumentException` → `_objc_terminate` → `SIGABRT`.

## Crash signature (from `~/Library/Logs/DiagnosticReports/Usage4Claude-*.ips`)

```
-[__SwiftValue unsignedIntegerValue]: unrecognized selector sent to instance 0x...
   NSUsingGraphicsStateForHints_drawWithBlock_
   -[NSImageRep drawInRect:fromRect:operation:fraction:respectFlipped:hints:]
   -[NSImage   drawInRect:fromRect:operation:fraction:respectFlipped:hints:]
   Usage4Claude + 235824                   <- ImageHelper.createSquareIcon
   ...
   Combine PublishedSubject.send -> MenuBarManager sink -> updateMenuBarIcon
   _dispatch_main_queue_drain
```

Reachable on every `dataManager.$usageData` / `$codexUsageData` / `$hasAvailableUpdate` change (`MenuBarManager.swift:97-130`) via `MenuBarUI.updateMenuBarIcon` -> `MenuBarIconRenderer.createIcon` -> `ImageHelper.createSquareIcon` (used to render the Codex brand icon, `ImageHelper.swift:42-44`).

## Fix

One-line bridging correction -- wrap the interpolation value as `NSNumber` so AppKit can read it through the documented ObjC selector on all supported macOS versions:

```diff
-            hints: [.interpolation: NSImageInterpolation.high]
+            hints: [.interpolation: NSNumber(value: NSImageInterpolation.high.rawValue)]
```

The `NSGraphicsContext.current?.imageInterpolation = .high` on the line above is left untouched.

`grep -rn "hints:" Usage4Claude/ Tests/` confirms this is the only such call site in the project.

## Test plan

- [ ] Build via CI (existing release workflow)
- [ ] Install on macOS 13.7.x -> confirm app launches, signs in, and the menu-bar icon redraws on data refresh without a fresh `~/Library/Logs/DiagnosticReports/Usage4Claude-*.ips` entry
- [ ] Smoke check on macOS 14 / 15 -> menu-bar icon still renders with high-quality interpolation (no visual regression)

## Notes

- No behaviour change on macOS 14/15 -- same hint, just correctly bridged.
- No version bump or CHANGELOG entry included; maintainer can fold this into the next patch release (v3.1.1) at their preferred time.

---

Reporter context: I'm on macOS 13.7.4 (MacBookPro18,3, Apple Silicon). v3.1.0 from the GitHub Releases DMG aborts within seconds of any data refresh. Happy to test a v3.1.1 build once tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)