### PR TITLE
feat: add optional menu-bar reset countdown rings

### DIFF
--- a/Usage4Claude/App/MenuBarIconRenderer.swift
+++ b/Usage4Claude/App/MenuBarIconRenderer.swift
@@ -21,7 +21,7 @@ class MenuBarIconRenderer {
     /// 菜单栏品牌图标尺寸
     private let providerBrandIconSize: CGFloat = 16
     /// 菜单栏指标图标尺寸
-    private let metricIconSize: CGFloat = 18
+    private let metricIconSize: CGFloat = 22
     
     // MARK: - Initialization
     
@@ -241,9 +241,15 @@ class MenuBarIconRenderer {
             return createSimpleCircleIcon()
         }
 
-        // 为每个类型创建图标
-        let icons = types.compactMap { type in
-            createIconForType(type, data: data, isMonochrome: isMonochrome, button: button)
+        // 按类型顺序：每个用量圆环后紧跟其对应的时间圆环
+        // 例如 [5H用量][5H时间][7天用量][7天时间]
+        var icons: [NSImage] = []
+        for type in types {
+            guard let usageIcon = createIconForType(type, data: data, isMonochrome: isMonochrome, button: button) else { continue }
+            icons.append(usageIcon)
+            if let timeIcon = timeCircleFor(type: type, data: data, isMonochrome: isMonochrome, button: button) {
+                icons.append(timeIcon)
+            }
         }
 
         // 组合图标
@@ -252,7 +258,7 @@ class MenuBarIconRenderer {
         } else if icons.count == 1 {
             return icons[0]
         } else {
-            let combined = combineIcons(icons, spacing: 3.0, height: 18)
+            let combined = combineIcons(icons, spacing: 3.0, height: metricIconSize)
             combined.isTemplate = isMonochrome
             return combined
         }
@@ -271,14 +277,15 @@ class MenuBarIconRenderer {
             return createCombinedPercentageIcon(data: data, types: types, isMonochrome: isMonochrome, button: button)
         }
 
-        // 创建百分比图标
-        let percentageIcons = types.compactMap { type in
-            createIconForType(type, data: data, isMonochrome: isMonochrome, button: button)
-        }
-
-        // 组合 App 图标 + 百分比图标
+        // 组合 App 图标 + （每个用量圆环后紧跟其时间圆环）
         var allIcons = [appIconCopy]
-        allIcons.append(contentsOf: percentageIcons)
+        for type in types {
+            guard let usageIcon = createIconForType(type, data: data, isMonochrome: isMonochrome, button: button) else { continue }
+            allIcons.append(usageIcon)
+            if let timeIcon = timeCircleFor(type: type, data: data, isMonochrome: isMonochrome, button: button) {
+                allIcons.append(timeIcon)
+            }
+        }
 
         let combined = combineIcons(allIcons, spacing: 3.0, height: metricIconSize)
         combined.isTemplate = isMonochrome
@@ -287,7 +294,7 @@ class MenuBarIconRenderer {
     
     // MARK: - Icon Drawing - Colored Mode (彩色模式)
 
-    private func createCircleImage(percentage: Double, size: NSSize, useSevenDayColor: Bool = false, colorOverride: NSColor? = nil, useDashedStyle: Bool = false, button: NSStatusBarButton?, removeBackground: Bool = false) -> NSImage {
+    private func createCircleImage(percentage: Double, size: NSSize, useSevenDayColor: Bool = false, colorOverride: NSColor? = nil, useDashedStyle: Bool = false, button: NSStatusBarButton?, removeBackground: Bool = false, centerText: String? = nil) -> NSImage {
         let image = NSImage(size: size)
         image.lockFocus()
 
@@ -352,9 +359,18 @@ class MenuBarIconRenderer {
         progressPath.lineCapStyle = percentage >= 100 ? .butt : .round
         progressPath.stroke()
 
-        let fontSize: CGFloat = percentage >= 100 ? size.width * 0.275 : size.width * 0.4
-        let font = NSFont.systemFont(ofSize: fontSize, weight: percentage >= 100 ? .bold : .semibold)
-        let text = "\(Int(percentage))"
+        let text = centerText ?? "\(Int(percentage))"
+        let fontSize: CGFloat
+        let fontWeight: NSFont.Weight
+        if centerText != nil {
+            // 时间圆环：按文本长度自适应字号（如 "45m"/"2h"/"5d"）
+            fontSize = text.count >= 3 ? size.width * 0.30 : size.width * 0.40
+            fontWeight = .semibold
+        } else {
+            fontSize = percentage >= 100 ? size.width * 0.275 : size.width * 0.4
+            fontWeight = percentage >= 100 ? .bold : .semibold
+        }
+        let font = NSFont.systemFont(ofSize: fontSize, weight: fontWeight)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
 
@@ -369,7 +385,7 @@ class MenuBarIconRenderer {
 
     // MARK: - Icon Drawing - Template Mode (单色模式)
 
-    private func createCircleTemplateImage(percentage: Double, size: NSSize, useSevenDayStyle: Bool = false, button: NSStatusBarButton? = nil, removeBackground: Bool = false) -> NSImage {
+    private func createCircleTemplateImage(percentage: Double, size: NSSize, useSevenDayStyle: Bool = false, button: NSStatusBarButton? = nil, removeBackground: Bool = false, centerText: String? = nil) -> NSImage {
         let image = NSImage(size: size)
         image.lockFocus()
 
@@ -420,9 +436,18 @@ class MenuBarIconRenderer {
         progressPath.lineCapStyle = percentage >= 100 ? .butt : .round
         progressPath.stroke()
 
-        let fontSize: CGFloat = percentage >= 100 ? size.width * 0.275 : size.width * 0.4
-        let font = NSFont.systemFont(ofSize: fontSize, weight: percentage >= 100 ? .bold : .semibold)
-        let text = "\(Int(percentage))"
+        let text = centerText ?? "\(Int(percentage))"
+        let fontSize: CGFloat
+        let fontWeight: NSFont.Weight
+        if centerText != nil {
+            // 时间圆环：按文本长度自适应字号（如 "45m"/"2h"/"5d"）
+            fontSize = text.count >= 3 ? size.width * 0.30 : size.width * 0.40
+            fontWeight = .semibold
+        } else {
+            fontSize = percentage >= 100 ? size.width * 0.275 : size.width * 0.4
+            fontWeight = percentage >= 100 ? .bold : .semibold
+        }
+        let font = NSFont.systemFont(ofSize: fontSize, weight: fontWeight)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
         let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.black, .paragraphStyle: paragraphStyle]
@@ -438,7 +463,7 @@ class MenuBarIconRenderer {
 
     /// 创建简单圆形图标（备用）
     private func createSimpleCircleIcon() -> NSImage {
-        let size = NSSize(width: 18, height: 18)
+        let size = NSSize(width: metricIconSize, height: metricIconSize)
         let image = NSImage(size: size)
         image.lockFocus()
 
@@ -478,6 +503,101 @@ class MenuBarIconRenderer {
         badgedImage.isTemplate = baseImage.isTemplate
 
         return badgedImage
+    }
+
+    // MARK: - Countdown Circle Rendering
+
+    /// 窗口总时长，用于计算"已过去比例"，使时间圆环可与相邻用量圆环直接对比
+    private let fiveHourWindowSeconds: TimeInterval = 5 * 60 * 60
+    private let sevenDayWindowSeconds: TimeInterval = 7 * 24 * 60 * 60
+
+    /// 为指定限制类型构建对应的时间圆环（紧跟在该类型的用量圆环之后显示）
+    /// - 环填充 = 当前窗口"已过去"的比例（与相邻用量环同向，便于判断用量是否超前于时间）
+    /// - 中心文本 = 剩余时间（紧凑自适应单位）
+    /// - 5小时 = 红色，7天 = 橙色；其它类型无时间圆环（返回 nil）
+    private func timeCircleFor(
+        type: LimitType,
+        data: UsageData,
+        isMonochrome: Bool,
+        button: NSStatusBarButton?
+    ) -> NSImage? {
+        // 用户可在设置中关闭菜单栏倒计时（关闭时不绘制时间圆环）
+        guard settings.menuBarCountdownEnabled else { return nil }
+        switch type {
+        case .fiveHour:
+            // 窗口重置后尚未使用 token 时 API 无 resets_at；此时显示满窗占位（空环 + 整窗时间），
+            // 让时钟始终与用量圆环成对出现，首次用量产生后平滑切换为真实倒计时。
+            let remaining = placeholderRemaining(data.fiveHour?.resetsIn, window: fiveHourWindowSeconds)
+            return makeTimeCircle(
+                remaining: remaining,
+                windowSeconds: fiveHourWindowSeconds,
+                text: timeCircleText(remaining: remaining, isShortWindow: true),
+                color: .systemRed,
+                isMonochrome: isMonochrome,
+                button: button
+            )
+        case .sevenDay:
+            let remaining = placeholderRemaining(data.sevenDay?.resetsIn, window: sevenDayWindowSeconds)
+            return makeTimeCircle(
+                remaining: remaining,
+                windowSeconds: sevenDayWindowSeconds,
+                text: timeCircleText(remaining: remaining, isShortWindow: false),
+                color: .systemOrange,
+                isMonochrome: isMonochrome,
+                button: button
+            )
+        default:
+            return nil
+        }
+    }
+
+    /// 计算时间圆环使用的"剩余秒数"：
+    /// - 有有效 resets_at（resetsIn > 0）时返回真实剩余（并夹在整窗内）
+    /// - 窗口刚重置、尚无 resets_at，或剩余 <= 0 时，回退为整个窗口 → 空环 + 满窗占位
+    private func placeholderRemaining(_ resetsIn: TimeInterval?, window: TimeInterval) -> TimeInterval {
+        guard let resetsIn = resetsIn, resetsIn > 0 else { return window }
+        return min(resetsIn, window)
+    }
+
+    /// 绘制单个时间圆环，复用用量圆环的绘制逻辑（环=已过去比例，中心=剩余时间文本）
+    private func makeTimeCircle(
+        remaining: TimeInterval,
+        windowSeconds: TimeInterval,
+        text: String,
+        color: NSColor,
+        isMonochrome: Bool,
+        button: NSStatusBarButton?
+    ) -> NSImage {
+        // 已过去比例（0-100），与用量百分比同尺度
+        let elapsed = max(0, min(100, (1 - remaining / windowSeconds) * 100))
+        let size = NSSize(width: metricIconSize, height: metricIconSize)
+        let removeBackground = settings.iconStyleMode == .colorTranslucent
+
+        if isMonochrome {
+            return createCircleTemplateImage(percentage: elapsed, size: size, button: button, removeBackground: true, centerText: text)
+        }
+        return createCircleImage(percentage: elapsed, size: size, colorOverride: color, button: button, removeBackground: removeBackground, centerText: text)
+    }
+
+    /// 紧凑的时间圆环中心文本（≤3字符，自适应单位）
+    /// - 短窗口（5小时）: <60分钟显示 "Nm"，否则 "Nh"
+    /// - 长窗口（7天）: <24小时显示 "Nh"，否则 "Nd"
+    private func timeCircleText(remaining: TimeInterval, isShortWindow: Bool) -> String {
+        if isShortWindow {
+            let totalMinutes = remaining / 60.0
+            if totalMinutes < 60 {
+                let m = max(1, Int(totalMinutes.rounded()))
+                if m < 60 { return "\(m)m" }
+                // 四舍五入恰好到 60 分钟时，按 1 小时显示
+            }
+            // ≥1 小时：四舍五入到最近的整点（剩余分钟 >30 进位，<30 舍去）
+            let hours = max(1, Int((remaining / 3600).rounded()))
+            return "\(hours)h"
+        } else {
+            let hours = Int(ceil(remaining / 3600))
+            if hours < 24 { return "\(hours)h" }
+            return "\(hours / 24)d"
+        }
     }
 
     // MARK: - Icon Combination Methods (v2.0)
@@ -541,18 +661,18 @@ class MenuBarIconRenderer {
             let percentage = data.fiveHour?.percentage ?? (showPlaceholder ? 0 : nil)
             guard let percentage = percentage else { return nil }
             if isMonochrome {
-                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: 18, height: 18), button: button, removeBackground: true)
+                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: metricIconSize, height: metricIconSize), button: button, removeBackground: true)
             } else {
-                return createCircleImage(percentage: percentage, size: NSSize(width: 18, height: 18), button: button, removeBackground: removeBackground)
+                return createCircleImage(percentage: percentage, size: NSSize(width: metricIconSize, height: metricIconSize), button: button, removeBackground: removeBackground)
             }
 
         case .sevenDay:
             let percentage = data.sevenDay?.percentage ?? (showPlaceholder ? 0 : nil)
             guard let percentage = percentage else { return nil }
             if isMonochrome {
-                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: 18, height: 18), useSevenDayStyle: true, button: button, removeBackground: true)
+                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: metricIconSize, height: metricIconSize), useSevenDayStyle: true, button: button, removeBackground: true)
             } else {
-                return createCircleImage(percentage: percentage, size: NSSize(width: 18, height: 18), useSevenDayColor: true, button: button, removeBackground: removeBackground)
+                return createCircleImage(percentage: percentage, size: NSSize(width: metricIconSize, height: metricIconSize), useSevenDayColor: true, button: button, removeBackground: removeBackground)
             }
 
         case .opusWeekly:
@@ -596,17 +716,17 @@ class MenuBarIconRenderer {
         switch type {
         case .codexPrimary:
             if isMonochrome {
-                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: 18, height: 18), button: button, removeBackground: true)
+                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: metricIconSize, height: metricIconSize), button: button, removeBackground: true)
             }
             let color = UsageColorScheme.codexPrimaryColorAdaptive(percentage, for: button)
-            return createCircleImage(percentage: percentage, size: NSSize(width: 18, height: 18), colorOverride: color, button: button, removeBackground: removeBackground)
+            return createCircleImage(percentage: percentage, size: NSSize(width: metricIconSize, height: metricIconSize), colorOverride: color, button: button, removeBackground: removeBackground)
 
         case .codexSecondary:
             if isMonochrome {
-                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: 18, height: 18), useSevenDayStyle: true, button: button, removeBackground: true)
+                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: metricIconSize, height: metricIconSize), useSevenDayStyle: true, button: button, removeBackground: true)
             }
             let color = UsageColorScheme.codexSecondaryColorAdaptive(percentage, for: button)
-            return createCircleImage(percentage: percentage, size: NSSize(width: 18, height: 18), colorOverride: color, useDashedStyle: true, button: button, removeBackground: removeBackground)
+            return createCircleImage(percentage: percentage, size: NSSize(width: metricIconSize, height: metricIconSize), colorOverride: color, useDashedStyle: true, button: button, removeBackground: removeBackground)
 
         case .codexExtraUsage:
             let color = UsageColorScheme.codexExtraUsageColorAdaptive(percentage, for: button)

--- a/Usage4Claude/App/MenuBarManager.swift
+++ b/Usage4Claude/App/MenuBarManager.swift
@@ -229,6 +229,9 @@ class MenuBarManager: ObservableObject {
 
                 // 立即更新图标，无需等待
                 self.updateMenuBarIcon()
+
+                // "菜单栏重置倒计时"开关可能变化，同步倒计时重绘定时器
+                self.syncMenuBarCountdownTimer()
             }
             .store(in: &cancellables)
 
@@ -400,6 +403,21 @@ class MenuBarManager: ObservableObject {
     /// 开始数据刷新
     func startRefreshing() {
         dataManager.startRefreshing()
+        // 按"菜单栏重置倒计时"开关启动 / 停止倒计时重绘定时器
+        syncMenuBarCountdownTimer()
+    }
+
+    /// 根据"菜单栏重置倒计时"开关启动或停止倒计时重绘定时器
+    /// 启用时定期重绘菜单栏以刷新倒计时文本；关闭时停止定时器，避免无谓重绘
+    /// （startMenuBarCountdownTimer 重复调用安全：同标识符定时器会先被取消再重建）
+    private func syncMenuBarCountdownTimer() {
+        if settings.menuBarCountdownEnabled {
+            dataManager.startMenuBarCountdownTimer { [weak self] in
+                self?.updateMenuBarIcon()
+            }
+        } else {
+            dataManager.stopMenuBarCountdownTimer()
+        }
     }
     
     // MARK: - Settings Window

--- a/Usage4Claude/App/MenuBarUI.swift
+++ b/Usage4Claude/App/MenuBarUI.swift
@@ -648,6 +648,11 @@ class MenuBarUI {
             key += "_extra\(Int(percentage))"
         }
 
+        // 菜单栏倒计时文本随时间变化，纳入缓存键以便每分钟自动刷新（关闭倒计时时不计入）
+        if settings.menuBarCountdownEnabled {
+            key += "_c5\(data.fiveHour?.menuBarCountdown ?? "")_c7\(data.sevenDay?.menuBarCountdown ?? "")"
+        }
+
         if let codex = codexUsageData {
             if let p = codex.primary { key += "_cxp\(Int(p.percentage))" }
             if let s = codex.secondary { key += "_cxs\(Int(s.percentage))" }

--- a/Usage4Claude/Helpers/DataRefreshManager.swift
+++ b/Usage4Claude/Helpers/DataRefreshManager.swift
@@ -298,6 +298,20 @@ class DataRefreshManager: ObservableObject {
         }
     }
 
+    /// 启动菜单栏倒计时刷新定时器
+    /// 周期性重绘菜单栏图标，使倒计时文本保持最新（仅本地重绘，不触发网络请求）
+    /// - Parameter updateHandler: 每次触发时调用的重绘闭包
+    func startMenuBarCountdownTimer(updateHandler: @escaping () -> Void) {
+        timerManager.schedule(TimerID.menuBarCountdown, interval: 30.0, repeats: true) {
+            updateHandler()
+        }
+    }
+
+    /// 停止菜单栏倒计时刷新定时器
+    func stopMenuBarCountdownTimer() {
+        timerManager.invalidate(TimerID.menuBarCountdown)
+    }
+
     // MARK: - App Nap Prevention
 
     /// 开始后台活动声明，防止 macOS App Nap 冻结定时器

--- a/Usage4Claude/Helpers/LocalizationHelper.swift
+++ b/Usage4Claude/Helpers/LocalizationHelper.swift
@@ -198,6 +198,8 @@ enum L {
         static var none: String { localized("display.none") }
         static var showIcon: String { localized("display.show_icon") }
         static var showPercentage: String { localized("display.show_percentage") }
+        static var menuBarCountdown: String { localized("display.menu_bar_countdown") }
+        static var menuBarCountdownDescription: String { localized("display.menu_bar_countdown_description") }
     }
     
     // MARK: - Icon Style Mode

--- a/Usage4Claude/Helpers/TimerManager.swift
+++ b/Usage4Claude/Helpers/TimerManager.swift
@@ -149,5 +149,7 @@ extension TimerManager {
         static let codexResetVerify3 = "codexResetVerify3"
         /// Codex accessToken 主动续期定时器（独立于用量拉取计时器）
         static let codexTokenRefresh = "codexTokenRefresh"
+        /// 菜单栏重置倒计时重绘定时器（30秒间隔）
+        static let menuBarCountdown = "menuBarCountdown"
     }
 }

--- a/Usage4Claude/Helpers/UsageData+Formatting.swift
+++ b/Usage4Claude/Helpers/UsageData+Formatting.swift
@@ -130,6 +130,35 @@ extension UsageData.LimitData {
         return L.UsageData.compactRemainingDays(days, hours)
     }
 
+    /// 菜单栏倒计时文本（紧凑、无后缀、语言无关）
+    /// - 用于菜单栏常驻显示距离重置的剩余时间
+    /// - 示例: "45m", "1h32m", "2d7h"；无重置时间或已重置时返回 nil
+    var menuBarCountdown: String? {
+        guard let resetsAt = resetsAt else { return nil }
+
+        let resetsIn = resetsAt.timeIntervalSinceNow
+        guard resetsIn > 0 else { return nil }
+
+        // 向上取整到分钟，与其它倒计时格式保持一致
+        let totalMinutes = Int(ceil(resetsIn / 60))
+
+        if totalMinutes < 60 {
+            return "\(totalMinutes)m"
+        }
+
+        let totalHours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+
+        if totalHours < 24 {
+            return "\(totalHours)h\(minutes)m"
+        }
+
+        let days = totalHours / 24
+        let hours = totalHours % 24
+
+        return "\(days)d\(hours)h"
+    }
+
     /// 格式化的重置时间（用于5小时限制）
     /// - 示例: "Today 15:07" / "Today 3:07 PM", "Tomorrow 09:30" / "Tomorrow 9:30 AM"
     var formattedCompactResetTime: String {

--- a/Usage4Claude/Models/UserSettings.swift
+++ b/Usage4Claude/Models/UserSettings.swift
@@ -475,6 +475,14 @@ class UserSettings: ObservableObject {
         }
     }
 
+    /// 是否在菜单栏显示重置倒计时圆环（5小时 / 7天窗口）
+    @Published var menuBarCountdownEnabled: Bool {
+        didSet {
+            defaults.set(menuBarCountdownEnabled, forKey: "menuBarCountdownEnabled")
+            NotificationCenter.default.post(name: .settingsChanged, object: nil)
+        }
+    }
+
     /// Popover 端是否应该显示自定义模式的占位符（0% 空壳）
     /// 仅当显示模式为 custom 且未开启"仅应用于菜单栏"时为 true
     var shouldShowCustomPlaceholderInPopover: Bool {
@@ -777,6 +785,9 @@ class UserSettings: ObservableObject {
         // 加载"自定义显示仅应用于菜单栏"开关，默认关闭（保持向后兼容）
         self.customDisplayMenuBarOnly = defaults.bool(forKey: "customDisplayMenuBarOnly")
 
+        // 加载"菜单栏重置倒计时"开关，默认开启
+        self.menuBarCountdownEnabled = defaults.object(forKey: "menuBarCountdownEnabled") as? Bool ?? true
+
         // 检查是否首次启动（如果没有保存过认证信息，就是首次启动）
         if !defaults.bool(forKey: "hasLaunched") {
             self.isFirstLaunch = true
@@ -894,6 +905,7 @@ class UserSettings: ObservableObject {
         displayMode = .smart
         customDisplayTypes = Self.defaultCustomDisplayTypes
         customDisplayMenuBarOnly = false
+        menuBarCountdownEnabled = true
         notificationsEnabled = true
 
         // 重置智能模式状态

--- a/Usage4Claude/Resources/de.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/de.lproj/Localizable.strings
@@ -124,6 +124,8 @@
 "display.none" = "Keine Anzeige";
 "display.show_icon" = "Symbol anzeigen";
 "display.show_percentage" = "Prozent anzeigen";
+"display.menu_bar_countdown" = "Reset-Countdown";
+"display.menu_bar_countdown_description" = "Zeigt für jedes Reset-Fenster (5 Stunden und 7 Tage) einen Countdown-Ring neben dem zugehörigen Nutzungsring in der Menüleiste an.";
 
 // MARK: - Refresh Interval
 "refresh.smart_mode" = "Intelligente Frequenz";

--- a/Usage4Claude/Resources/en.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/en.lproj/Localizable.strings
@@ -125,6 +125,8 @@
 "display.none" = "No Display";
 "display.show_icon" = "Show Icon";
 "display.show_percentage" = "Show Percentage";
+"display.menu_bar_countdown" = "Reset countdown";
+"display.menu_bar_countdown_description" = "Show a countdown ring for each reset window (5-hour and 7-day) next to its usage ring in the menu bar.";
 
 // MARK: - Refresh Interval
 "refresh.smart_mode" = "Smart Frequency";

--- a/Usage4Claude/Resources/fr.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/fr.lproj/Localizable.strings
@@ -125,6 +125,8 @@
 "display.none" = "Ne rien afficher";
 "display.show_icon" = "Afficher l'icône";
 "display.show_percentage" = "Afficher le pourcentage";
+"display.menu_bar_countdown" = "Compte à rebours de réinitialisation";
+"display.menu_bar_countdown_description" = "Affiche un anneau de compte à rebours pour chaque fenêtre de réinitialisation (5 heures et 7 jours) à côté de son anneau d'utilisation dans la barre de menus.";
 
 // MARK: - Refresh Interval
 "refresh.smart_mode" = "Fréquence intelligente";

--- a/Usage4Claude/Resources/ja.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ja.lproj/Localizable.strings
@@ -125,6 +125,8 @@
 "display.none" = "表示しない";
 "display.show_icon" = "アイコンを表示";
 "display.show_percentage" = "パーセンテージを表示";
+"display.menu_bar_countdown" = "リセットまでのカウントダウン";
+"display.menu_bar_countdown_description" = "メニューバーの各使用量リングの隣に、各リセット期間（5時間・7日）の残り時間を示すカウントダウンリングを表示します。";
 
 // MARK: - Refresh Interval
 "refresh.smart_mode" = "スマート頻度";

--- a/Usage4Claude/Resources/ko.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ko.lproj/Localizable.strings
@@ -125,6 +125,8 @@
 "display.none" = "표시 안 함";
 "display.show_icon" = "아이콘 표시";
 "display.show_percentage" = "백분율 표시";
+"display.menu_bar_countdown" = "재설정 카운트다운";
+"display.menu_bar_countdown_description" = "메뉴 막대의 각 사용량 링 옆에 각 재설정 주기(5시간 및 7일)의 남은 시간을 나타내는 카운트다운 링을 표시합니다.";
 
 // MARK: - Refresh Interval
 "refresh.smart_mode" = "스마트 간격";

--- a/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
@@ -125,6 +125,8 @@
 "display.none" = "不显示";
 "display.show_icon" = "显示图标";
 "display.show_percentage" = "显示百分比";
+"display.menu_bar_countdown" = "重置倒计时";
+"display.menu_bar_countdown_description" = "在菜单栏每个用量圆环旁显示一个倒计时圆环，分别对应 5 小时和 7 天窗口的重置时间。";
 
 // MARK: - Refresh Interval
 "refresh.smart_mode" = "智能频率";

--- a/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
@@ -125,6 +125,8 @@
 "display.none" = "不顯示";
 "display.show_icon" = "顯示圖示";
 "display.show_percentage" = "顯示百分比";
+"display.menu_bar_countdown" = "重置倒數計時";
+"display.menu_bar_countdown_description" = "在選單列每個用量圓環旁顯示一個倒數計時圓環，分別對應 5 小時與 7 天視窗的重置時間。";
 
 // MARK: - Refresh Interval
 "refresh.smart_mode" = "智慧頻率";

--- a/Usage4Claude/Views/Settings/Tabs/GeneralSettingsDisplaySection.swift
+++ b/Usage4Claude/Views/Settings/Tabs/GeneralSettingsDisplaySection.swift
@@ -101,6 +101,24 @@ struct GeneralSettingsDisplaySection: View {
                         .disabled(settings.iconDisplayMode == .percentageOnly)
                     }
                 }
+
+                Divider()
+
+                // 菜单栏重置倒计时开关
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle(isOn: $settings.menuBarCountdownEnabled) {
+                        Text(L.Display.menuBarCountdown)
+                            .font(.subheadline)
+                    }
+                    .toggleStyle(.checkbox)
+                    .focusable(false)
+
+                    Text(L.Display.menuBarCountdownDescription)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.leading, 20)
+                }
             }
         }
     }


### PR DESCRIPTION
## What this adds

Two **reset-countdown rings** in the menu bar, interleaved with the existing usage rings so each usage ring is immediately followed by its time ring:

`(5h usage)(5h countdown – red)(weekly usage)(7d countdown – orange)`

Each time ring fills with the **percentage of its window already elapsed** — same scale and drawing as the usage rings — so the time ring visibly races its neighbour. If the usage ring is ahead of the time ring, you're spending that window's quota faster than the clock is running it down. The ring's center shows the **remaining time** in a compact, adaptive unit:

- 5-hour (red): minutes under an hour, otherwise hours
- 7-day (orange): hours under a day, otherwise days

**Reset edge case:** right after a window resets, the API returns no `resets_at` (the timer only starts on first token use). During that gap the ring shows an empty ring + a full-window placeholder (`5h` / `7d`) instead of vanishing, then transitions to the live countdown once usage starts — so the time ring always stays paired with its usage ring.

## Setting + i18n

- New **"Reset countdown"** checkbox under **General → display settings**.
- **Defaulted on.** Happy to flip it to opt-in (off by default) if you'd prefer — it's a one-liner in `UserSettings.init` / `resetToDefaults()`.
- Localized across all six bundled languages (en, fr, ja, ko, zh-Hans, zh-Hant). The non-English strings are my best effort — please review/adjust.
- When the toggle is **off**: `timeCircleFor` returns `nil` (no rings drawn), the 30 s repaint timer is stopped, and the countdown text is dropped from the icon cache key (so toggling busts the cache cleanly).

## Implementation notes

- `MenuBarIconRenderer` — `timeCircleFor` / `makeTimeCircle` / `timeCircleText`; a `centerText` parameter added to the existing circle-drawing helpers so time rings reuse the usage-ring rendering path.
- `UsageData+Formatting` — `menuBarCountdown` text + cache-key contribution.
- `DataRefreshManager` — a 30 s `menuBarCountdown` repaint timer (local repaint only, no network request).
- `MenuBarManager` — starts/stops that timer according to the setting.
- `UserSettings` / `GeneralSettingsView` / `LocalizationHelper` / 6× `Localizable.strings` — the toggle and its strings.

Rebased on `main` (v3.2.0). Builds and runs locally on macOS (ad-hoc signed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
