### PR TITLE
feat: show per-model weekly usage (e.g. Fable) from the new limits[] API

### DIFF
--- a/Tests/Usage4ClaudeCoreTests/UsageResponseTests.swift
+++ b/Tests/Usage4ClaudeCoreTests/UsageResponseTests.swift
@@ -247,4 +247,116 @@ final class UsageResponseTests: XCTestCase {
         let usage = try decode(json).toUsageData()
         XCTAssertNil(usage.extraUsage)
     }
+
+    // MARK: - Scoped model weekly limits (Claude 5 `limits[]`)
+    //
+    // In the Claude 5 era the API stopped populating `seven_day_opus` /
+    // `seven_day_sonnet` and moved per-model weekly limits into a `limits`
+    // array. Each model-scoped entry carries `scope.model.display_name`
+    // (e.g. "Fable") + `percent`. These flow into the opus/sonnet display
+    // slots so the existing weekly-limit UI lights up, with the real model
+    // name surfaced via `opusModelName` / `sonnetModelName`.
+
+    func testScopedModelWeeklyLimitPopulatesOpusSlotWithName() throws {
+        let json = """
+        {
+            "five_hour": { "utilization": 20, "resets_at": "2026-07-03T18:19:59.000Z" },
+            "seven_day": { "utilization": 13, "resets_at": "2026-07-08T16:59:59.000Z" },
+            "seven_day_opus": null,
+            "seven_day_sonnet": null,
+            "limits": [
+                { "kind": "session",     "group": "session", "percent": 20, "scope": null },
+                { "kind": "weekly_all",  "group": "weekly",  "percent": 13, "scope": null },
+                { "kind": "weekly_scoped", "group": "weekly", "percent": 21,
+                  "resets_at": "2026-07-08T16:59:59.000Z",
+                  "scope": { "model": { "id": null, "display_name": "Fable" } },
+                  "is_active": true }
+            ]
+        }
+        """
+        let usage = try decode(json).toUsageData()
+        XCTAssertEqual(usage.opus?.percentage, 21)
+        XCTAssertEqual(usage.opusModelName, "Fable")
+        XCTAssertNotNil(usage.opus?.resetsAt)
+        XCTAssertNil(usage.sonnet)
+    }
+
+    func testLegacyOpusFieldTakesPrecedenceOverScopedModel() throws {
+        // If the API ever returns both the legacy field and a limits entry,
+        // the dedicated field wins and no model-name override is applied.
+        let json = """
+        {
+            "five_hour": { "utilization": 20, "resets_at": "2026-07-03T18:19:59.000Z" },
+            "seven_day": null,
+            "seven_day_opus": { "utilization": 40, "resets_at": "2026-07-08T16:59:59.000Z" },
+            "seven_day_sonnet": null,
+            "limits": [
+                { "kind": "weekly_scoped", "group": "weekly", "percent": 21,
+                  "scope": { "model": { "display_name": "Fable" } } }
+            ]
+        }
+        """
+        let usage = try decode(json).toUsageData()
+        XCTAssertEqual(usage.opus?.percentage, 40)
+        XCTAssertNil(usage.opusModelName)
+    }
+
+    func testTwoScopedModelsFillOpusThenSonnet() throws {
+        let json = """
+        {
+            "five_hour": { "utilization": 20, "resets_at": "2026-07-03T18:19:59.000Z" },
+            "seven_day": null,
+            "seven_day_opus": null,
+            "seven_day_sonnet": null,
+            "limits": [
+                { "kind": "weekly_scoped", "group": "weekly", "percent": 21,
+                  "scope": { "model": { "display_name": "Fable" } } },
+                { "kind": "weekly_scoped", "group": "weekly", "percent": 8,
+                  "scope": { "model": { "display_name": "Opus" } } }
+            ]
+        }
+        """
+        let usage = try decode(json).toUsageData()
+        XCTAssertEqual(usage.opus?.percentage, 21)
+        XCTAssertEqual(usage.opusModelName, "Fable")
+        XCTAssertEqual(usage.sonnet?.percentage, 8)
+        XCTAssertEqual(usage.sonnetModelName, "Opus")
+    }
+
+    func testNonModelScopedLimitsAreIgnored() throws {
+        // session / weekly_all entries carry no scope.model — they must not
+        // create phantom model rows.
+        let json = """
+        {
+            "five_hour": { "utilization": 20, "resets_at": "2026-07-03T18:19:59.000Z" },
+            "seven_day": null,
+            "seven_day_opus": null,
+            "seven_day_sonnet": null,
+            "limits": [
+                { "kind": "session",    "group": "session", "percent": 20, "scope": null },
+                { "kind": "weekly_all", "group": "weekly",  "percent": 13, "scope": null }
+            ]
+        }
+        """
+        let usage = try decode(json).toUsageData()
+        XCTAssertNil(usage.opus)
+        XCTAssertNil(usage.sonnet)
+        XCTAssertNil(usage.opusModelName)
+    }
+
+    func testMissingLimitsArrayLeavesScopedSlotsNil() throws {
+        // Backward compatibility: responses without a `limits` array behave
+        // exactly as before.
+        let json = """
+        {
+            "five_hour": { "utilization": 20, "resets_at": "2026-07-03T18:19:59.000Z" },
+            "seven_day": null,
+            "seven_day_opus": null,
+            "seven_day_sonnet": null
+        }
+        """
+        let usage = try decode(json).toUsageData()
+        XCTAssertNil(usage.opus)
+        XCTAssertNil(usage.opusModelName)
+    }
 }

--- a/Usage4Claude/Models/ClaudeAPIResponseModels.swift
+++ b/Usage4Claude/Models/ClaudeAPIResponseModels.swift
@@ -53,12 +53,42 @@ nonisolated struct UsageResponse: Codable, Sendable {
     /// 7天 Sonnet 用量限制数据（新字段）
     let seven_day_sonnet: LimitUsage?
 
+    /// 新版 API 的统一限制数组（Claude 5 时代）。
+    /// 每周针对具体模型的限制（如 Fable）不再走 `seven_day_opus` / `seven_day_sonnet`
+    /// 独立字段，而是以 `kind == "weekly_scoped"` 的条目出现在这里，
+    /// 通过 `scope.model.display_name` 标识具体模型。
+    let limits: [LimitEntry]?
+
     /// 通用限制用量详情（适用于5小时、7天等各种限制）
     struct LimitUsage: Codable, Sendable {
         /// 当前使用率 (0-100，可以是浮点数)
         let utilization: Double
         /// 重置时间（ISO 8601 格式），nil 表示尚未开始使用
         let resets_at: String?
+    }
+
+    /// 新版 `limits` 数组中的单个条目。
+    /// - `kind`: "session" / "weekly_all" / "weekly_scoped" 等
+    /// - `percent`: 使用百分比 (0-100)
+    /// - `scope.model.display_name`: 当限制针对具体模型时给出模型名（如 "Fable"）
+    struct LimitEntry: Codable, Sendable {
+        let kind: String?
+        let group: String?
+        let percent: Double?
+        let severity: String?
+        let resets_at: String?
+        let is_active: Bool?
+        let scope: Scope?
+
+        struct Scope: Codable, Sendable {
+            let model: Model?
+            let surface: String?
+
+            struct Model: Codable, Sendable {
+                let id: String?
+                let display_name: String?
+            }
+        }
     }
 
     /// 将 API 响应转换为应用内部使用的 UsageData 模型
@@ -78,8 +108,8 @@ nonisolated struct UsageResponse: Codable, Sendable {
             return UsageData.LimitData(percentage: parsed.percentage, resetsAt: parsed.resetsAt)
         }()
 
-        // 解析 Opus 限制数据（仅当存在且有效时）
-        let opusData: UsageData.LimitData? = {
+        // 解析 Opus 限制数据（旧版独立字段，仅当存在且有效时）
+        let legacyOpus: UsageData.LimitData? = {
             guard let opus = seven_day_opus else {
                 return nil
             }
@@ -90,8 +120,8 @@ nonisolated struct UsageResponse: Codable, Sendable {
             return UsageData.LimitData(percentage: parsed.percentage, resetsAt: parsed.resetsAt)
         }()
 
-        // 解析 Sonnet 限制数据（仅当存在且有效时）
-        let sonnetData: UsageData.LimitData? = {
+        // 解析 Sonnet 限制数据（旧版独立字段，仅当存在且有效时）
+        let legacySonnet: UsageData.LimitData? = {
             guard let sonnet = seven_day_sonnet else {
                 return nil
             }
@@ -102,13 +132,55 @@ nonisolated struct UsageResponse: Codable, Sendable {
             return UsageData.LimitData(percentage: parsed.percentage, resetsAt: parsed.resetsAt)
         }()
 
+        // 解析新版 `limits` 数组里针对具体模型的每周限制（Claude 5 时代，如 Fable）。
+        // 这些限制不再走 seven_day_opus / seven_day_sonnet 独立字段，而是以带
+        // scope.model 的条目出现在 limits 中。保留出现顺序，过滤掉没有模型名
+        // 或没有百分比的条目。
+        var scopedModels: [(name: String, limit: UsageData.LimitData)] = (limits ?? []).compactMap { entry in
+            guard let name = entry.scope?.model?.display_name, !name.isEmpty,
+                  let percent = entry.percent else { return nil }
+            let limit = UsageData.LimitData(percentage: percent, resetsAt: parseResetDate(entry.resets_at))
+            return (name, limit)
+        }
+
+        // 旧字段优先；缺失时用 limits 里的模型限制回填 opus / sonnet 两个展示槽位，
+        // 并记录对应的真实模型名，以便 UI 动态显示（如用 "Fable" 取代 "Opus Weekly"）。
+        var opusData = legacyOpus
+        var opusModelName: String? = nil
+        var sonnetData = legacySonnet
+        var sonnetModelName: String? = nil
+
+        if opusData == nil, !scopedModels.isEmpty {
+            let first = scopedModels.removeFirst()
+            opusData = first.limit
+            opusModelName = first.name
+        }
+        if sonnetData == nil, !scopedModels.isEmpty {
+            let second = scopedModels.removeFirst()
+            sonnetData = second.limit
+            sonnetModelName = second.name
+        }
+
         return UsageData(
             fiveHour: UsageData.LimitData(percentage: fiveHourData.percentage, resetsAt: fiveHourData.resetsAt),
             sevenDay: sevenDayData,
             opus: opusData,
             sonnet: sonnetData,
-            extraUsage: nil  // Extra Usage 将在阶段5通过单独的 API 获取
+            extraUsage: nil,  // Extra Usage 将在阶段5通过单独的 API 获取
+            opusModelName: opusModelName,
+            sonnetModelName: sonnetModelName
         )
+    }
+
+    /// 解析 ISO 8601 重置时间字符串为 Date（四舍五入到秒）。
+    /// 与 parseLimitData 内的时间解析逻辑保持一致，供 limits 数组条目复用。
+    private func parseResetDate(_ resetString: String?) -> Date? {
+        guard let resetString = resetString else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: resetString) else { return nil }
+        let rounded = round(date.timeIntervalSinceReferenceDate)
+        return Date(timeIntervalSinceReferenceDate: rounded)
     }
 
     /// 解析单个限制的数据（5小时或7天）
@@ -227,12 +299,39 @@ struct UsageData: Sendable {
     let fiveHour: LimitData?
     /// 7天限制数据（可选）
     let sevenDay: LimitData?
-    /// Opus 每周限制数据（可选）
+    /// Opus 每周限制数据（可选）。在 Claude 5 时代，此槽位可承载来自新版
+    /// `limits` 数组的“针对具体模型的每周限制”（如 Fable），真实模型名见 `opusModelName`。
     let opus: LimitData?
-    /// Sonnet 每周限制数据（可选）
+    /// Sonnet 每周限制数据（可选）。同上，可承载第二个模型的每周限制。
     let sonnet: LimitData?
     /// Extra Usage 限额数据（可选）
     let extraUsage: ExtraUsageData?
+
+    /// opus 槽位对应的真实模型显示名（如 "Fable"）。为 nil 时 UI 回退到默认的
+    /// “Opus Weekly” 本地化文案；非 nil 时按此名称展示。
+    let opusModelName: String?
+    /// sonnet 槽位对应的真实模型显示名。语义同 `opusModelName`。
+    let sonnetModelName: String?
+
+    /// 显式成员初始化器。新增的 `opusModelName` / `sonnetModelName` 提供默认值，
+    /// 这样既能在 toUsageData() 中传入模型名，又不破坏其它以旧标签调用的构造点。
+    init(
+        fiveHour: LimitData?,
+        sevenDay: LimitData?,
+        opus: LimitData?,
+        sonnet: LimitData?,
+        extraUsage: ExtraUsageData?,
+        opusModelName: String? = nil,
+        sonnetModelName: String? = nil
+    ) {
+        self.fiveHour = fiveHour
+        self.sevenDay = sevenDay
+        self.opus = opus
+        self.sonnet = sonnet
+        self.extraUsage = extraUsage
+        self.opusModelName = opusModelName
+        self.sonnetModelName = sonnetModelName
+    }
 
     /// 单个限制的数据（5小时、7天、Opus、Sonnet）
     struct LimitData: Sendable {

--- a/Usage4Claude/Services/ClaudeAPIService.swift
+++ b/Usage4Claude/Services/ClaudeAPIService.swift
@@ -152,13 +152,15 @@ class ClaudeAPIService {
                 return
             }
 
-            // 创建包含 Extra Usage 的完整数据
+            // 创建包含 Extra Usage 的完整数据（保留 scoped 模型名，如 Fable）
             finalData = UsageData(
                 fiveHour: finalData.fiveHour,
                 sevenDay: finalData.sevenDay,
                 opus: finalData.opus,
                 sonnet: finalData.sonnet,
-                extraUsage: extraUsageData  // 可能为 nil
+                extraUsage: extraUsageData,  // 可能为 nil
+                opusModelName: finalData.opusModelName,
+                sonnetModelName: finalData.sonnetModelName
             )
 
             completion(.success(finalData))
@@ -606,7 +608,9 @@ class ClaudeAPIService {
                         sevenDay: usageData.sevenDay,
                         opus: usageData.opus,
                         sonnet: usageData.sonnet,
-                        extraUsage: extraResponse.toExtraUsageData()
+                        extraUsage: extraResponse.toExtraUsageData(),
+                        opusModelName: usageData.opusModelName,
+                        sonnetModelName: usageData.sonnetModelName
                     )
                 }
 

--- a/Usage4Claude/Views/Components/UsageRowComponents.swift
+++ b/Usage4Claude/Views/Components/UsageRowComponents.swift
@@ -244,9 +244,11 @@ struct UnifiedLimitRow: View {
         case .sevenDay, .codexSecondary:
             return L.DetailRow.sevenDay
         case .opusWeekly:
-            return L.DetailRow.opusWeekly
+            // Claude 5 时代：此槽位可能承载来自 limits 数组的具体模型每周限制（如 Fable）。
+            // 有真实模型名则优先展示，否则回退到默认的 “Opus Weekly” 文案。
+            return data?.opusModelName ?? L.DetailRow.opusWeekly
         case .sonnetWeekly:
-            return L.DetailRow.sonnetWeekly
+            return data?.sonnetModelName ?? L.DetailRow.sonnetWeekly
         case .extraUsage, .codexExtraUsage:
             return L.DetailRow.extraUsage
         }


### PR DESCRIPTION
## Problem

On Claude 5–era accounts the app shows **no weekly per-model row at all** (previously "Opus Weekly" / "Sonnet Weekly"). The `/usage` responses now return `seven_day_opus` and `seven_day_sonnet` as `null`.

## Root cause

The usage API moved per-model weekly limits out of the dedicated `seven_day_opus` / `seven_day_sonnet` fields and into a unified `limits` array. Each model-scoped entry identifies its model via `scope.model.display_name`:

```json
{
  "kind": "weekly_scoped",
  "group": "weekly",
  "percent": 21,
  "resets_at": "2026-07-08T16:59:59Z",
  "scope": { "model": { "display_name": "Fable" } },
  "is_active": true
}
```

Since the app only decoded the old fields, these limits were dropped.

## Fix

- Decode the new `limits` array in `UsageResponse` (`LimitEntry` + `scope.model`).
- In `toUsageData()`, map model-scoped weekly entries into the existing `opus` / `sonnet` display slots and record the real model name on new `UsageData.opusModelName` / `sonnetModelName` fields.
- `UnifiedLimitRow` shows that name in the row label, falling back to the localized "Opus/Sonnet Weekly" string when no name is present.
- Preserve the model names through the extra-usage merge on both the OAuth and session-key fetch paths.

This reuses all existing weekly-limit machinery (menu-bar icon, popover row, smart/custom display, colors), so the diff stays small and no new `LimitType` cases or localization keys are required.

## Screenshot

<img width="332" height="343" alt="Screenshot 2026-07-04 at 03 46 05" src="https://github.com/user-attachments/assets/8b647056-a505-4728-9779-f8d9c08205d0" />

_The **Fable** weekly limit rendering live — its own row (and menu-bar icon) alongside the 5-hour and 7-day limits, with the real model name and reset time._

## Backward compatibility

- The legacy `seven_day_opus` / `seven_day_sonnet` fields still take precedence when present.
- `limits` is optional; responses without it behave exactly as before.
- `UsageData` gains an explicit initializer whose new parameters default to `nil`, so existing construction sites are unchanged.

## Tests

Adds `UsageResponseTests` coverage:

- scoped-model extraction populates the slot + exposes the model name,
- legacy field precedence over a scoped entry,
- two scoped models fill opus then sonnet,
- non-model limits (`session` / `weekly_all`) are ignored,
- missing `limits` array stays `nil` (backward compat).

`swift test` → 34/34 passing.

## Notes

Verified against a live account: the row renders as e.g. **Fable 21%** with the correct reset time, alongside the 5-hour and 7-day rings. Happy to adjust the design (e.g. a dedicated scoped-models collection instead of reusing the opus/sonnet slots) if you'd prefer a different approach.
