### PR TITLE
Add Grok Build / SuperGrok usage monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Grok usage monitoring**: Track Grok Build / SuperGrok weekly quota, monthly included allowance, and credits in the menu bar and detail window
+- **Grok authentication**: Import credentials from Grok CLI `~/.grok/auth.json`, or sign in via OIDC device-code flow (`auth.x.ai`)
+- **Multi-provider layout**: Grok can be shown alone or side-by-side with Claude and/or Codex
+- **Grok limit types**: `grok_weekly`, `grok_monthly`, and `grok_credits` with dedicated colors, notifications, and custom display options
+
 ## [3.3.0] - 2026-07-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Usage4Claude — Project Overview
 
-A macOS menu bar app that monitors Claude / Codex subscription usage. Swift + SwiftUI + AppKit, targeting macOS 13+.
+A macOS menu bar app that monitors Claude / Codex / Grok subscription usage. Swift + SwiftUI + AppKit, targeting macOS 13+.
 
 ## Build & Test
 
@@ -12,8 +12,9 @@ A macOS menu bar app that monitors Claude / Codex subscription usage. Swift + Sw
 
 - `App/`: entry point, `MenuBarManager` (coordinates UI and data), icon rendering (`MenuBarIconRenderer`/`ShapeIconRenderer`)
 - `Services/`: `ClaudeAPIService` (cookie and OAuth dual paths), `CodexAPIService` (two-step auth),
+  `GrokAPIService` (OIDC refresh_token → access_token → billing API),
   `OAuthTokenCache` (actor: token caching + refresh single-flight), `KeychainManager` (uses UserDefaults in DEBUG!),
-  `*OAuth/` (PKCE + local callback server)
+  `*OAuth/` (PKCE + local callback server; Grok also supports device-code + auth.json import)
 - `Models/`: `UserSettings` is the settings facade; accounts/refresh policy/launch-at-login/appearance have been
   split out into `AccountStore`/`SmartRefreshPolicy`/`LaunchAtLoginManager`/`AppearanceManager`
 - `Helpers/DataRefreshManager.swift`: scheduled refresh, Codex's three-tier token refresh chain, reset verification

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,8 @@ let package = Package(
                 "Helpers/SensitiveDataRedactor.swift",
                 "Helpers/ResetTimeChange.swift",
                 "Helpers/NotificationDecisionEngine.swift",
-                "Models/CodexUsageData.swift"
+                "Models/CodexUsageData.swift",
+                "Models/GrokUsageData.swift"
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 [![Release](https://img.shields.io/github/v/release/f-is-h/Usage4Claude?style=flat-square)](https://github.com/f-is-h/Usage4Claude/releases)
 [![Downloads (all assets, all releases)](https://img.shields.io/github/downloads/f-is-h/Usage4Claude/total)](https://github.com/f-is-h/Usage4Claude/releases)
 
-**Track your Claude (and Codex) subscription quota — beautifully, in your menu bar.**
+**Track your Claude, Codex, and Grok subscription quota — beautifully, in your menu bar.**
 
-✨ **Monitors all Claude platforms: Web • Claude Code • Desktop • Mobile App • Cowork** ✨
+✨ **Monitors Claude platforms (Web • Claude Code • Desktop • Mobile • Cowork) plus Codex and Grok Build** ✨
 
 [Features](#-features) • [Installation](#-installation) • [User Guide](#-user-guide) • [FAQ](#-faq) • [Support](#-support)
 
@@ -27,15 +27,16 @@
 
 ### 🎯 Core Features
 
-- **📊 Real-time Monitoring** - Display Claude subscription (Free/Pro/Team/Max) usage quota in menu bar, with optional Codex monitoring
-- **🎯 Multi-Limit Support** - Claude supports 5-hour, 7-day, and Extra Usage limits plus weekly per-model usage for any number of models (e.g. Opus, Sonnet, Fable), while Codex supports 5-hour, 7-day, and Extra Usage/credits
+- **📊 Real-time Monitoring** - Display Claude subscription (Free/Pro/Team/Max) usage quota in menu bar, with optional Codex and Grok monitoring
+- **🎯 Multi-Limit Support** - Claude supports 5-hour, 7-day, and Extra Usage limits plus weekly per-model usage for any number of models (e.g. Opus, Sonnet, Fable); Codex supports 5-hour, 7-day, and Extra Usage/credits; Grok supports weekly, monthly, and credits
 - **🎨 Smart Display Mode** - Auto-detect and display all limit types with available data
 - **⚙️ Custom Display** - Manually select which limit types to display, supports any combination
 - **🎨 Smart Colors** - Automatic color changes based on usage, each limit type has its own color scheme
 - **🔔 Usage Notifications** - Warning notification at 90% usage, reset notification when quota resets
-- **👥 Multi-Account Management** - Support multiple Claude accounts / multiple organizations per account, plus independent Codex account management and quick switching
+- **👥 Multi-Account Management** - Support multiple Claude accounts / multiple organizations per account, plus independent Codex and Grok account management and quick switching
 - **🧩 Codex Support** - Optional Codex quota monitoring; use Codex alone or show it alongside Claude in a dual-column view (add a Codex account in settings to enable)
-- **🌐 Built-in Browser Login** - Claude login automatically extracts Session Key; Codex uses built-in browser login for ChatGPT authentication
+- **⚡ Grok Support** - Optional Grok Build / SuperGrok monitoring (weekly + monthly + credits). Import `~/.grok/auth.json` or sign in with device-code OAuth
+- **🌐 Built-in Browser Login** - Claude login automatically extracts Session Key; Codex uses built-in browser login for ChatGPT authentication; Grok supports device-code login
 - **🎨 Appearance Settings** - Support system default / light / dark appearance modes
 - **🕐 Time Format** - Support system default / 12-hour / 24-hour format
 - **⏰ Precise Timing** - Quota reset time displayed with minute precision
@@ -60,6 +61,17 @@ All platforms share the same usage quota, monitored in one place!
 - Supports Codex 5-hour, 7-day, and Extra Usage/credits information
 - Add a Codex account by logging in to ChatGPT with the built-in browser
 - Claude-only users need no extra setup; the existing experience stays unchanged until a Codex account is added
+
+### ⚡ Grok Support
+
+- Monitor Grok Build / SuperGrok weekly usage, monthly included allowance, and credits
+- Data source: Grok billing API (`cli-chat-proxy.grok.com/v1/billing`), same path used by the official Grok CLI `/usage`
+- Add a Grok account in **Settings → Authentication**:
+  - **Import Grok Auth** — pick Grok CLI’s `~/.grok/auth.json` (recommended if you already use `grok login`)
+  - **Grok Device Login** — browser device-code flow via `auth.x.ai`
+- Works alone or side-by-side with Claude and/or Codex
+- Existing Claude/Codex users need no extra setup until a Grok account is added
+
 
 ### 🎨 Personalization
 
@@ -160,7 +172,7 @@ Codex current colors:
 ### Settings
 
 **General** - Display options, menu bar theme, notification settings, appearance (system/light/dark), refresh mode, time format, language options, launch at login
-**Authentication** - Claude/Codex account management (add/delete/switch/alias editing), built-in browser login, Claude manual input, connection diagnostics
+**Authentication** - Claude/Codex/Grok account management (add/delete/switch/alias editing), Claude browser or manual input, Codex browser login, Grok auth.json import or device-code login, connection diagnostics
 **About** - Version info and related links
 
 ### Welcome Screen
@@ -593,7 +605,7 @@ and/or sell copies of the Software.
 
 ## ⚖️ Disclaimer
 
-This project is an independent third-party tool with no official affiliation with Anthropic, Claude AI, OpenAI, or Codex. Please comply with the relevant Terms of Service when using this software.
+This project is an independent third-party tool with no official affiliation with Anthropic, Claude AI, OpenAI, Codex, xAI, or Grok. Please comply with the relevant Terms of Service when using this software.
 
 ---
 

--- a/Tests/Usage4ClaudeCoreTests/GrokUsageResponseTests.swift
+++ b/Tests/Usage4ClaudeCoreTests/GrokUsageResponseTests.swift
@@ -1,0 +1,121 @@
+//
+//  GrokUsageResponseTests.swift
+//  Usage4ClaudeCoreTests
+//
+
+import XCTest
+@testable import Usage4ClaudeCore
+
+final class GrokUsageResponseTests: XCTestCase {
+
+    func testCreditsFormatWeeklyPercentFromProductUsage() throws {
+        let json = """
+        {
+          "config": {
+            "currentPeriod": {
+              "type": "USAGE_PERIOD_TYPE_WEEKLY",
+              "start": "2026-07-21T16:51:06.686549+00:00",
+              "end": "2026-07-28T16:51:06.686549+00:00"
+            },
+            "creditUsagePercent": 12.5,
+            "onDemandCap": { "val": 0 },
+            "onDemandUsed": { "val": 0 },
+            "productUsage": [
+              { "product": "GrokBuild", "usagePercent": 12.5 }
+            ],
+            "isUnifiedBillingUser": true,
+            "prepaidBalance": { "val": 0 },
+            "billingPeriodStart": "2026-07-21T16:51:06.686549+00:00",
+            "billingPeriodEnd": "2026-07-28T16:51:06.686549+00:00"
+          }
+        }
+        """
+        let credits = try JSONDecoder().decode(GrokCreditsBillingResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(credits.weeklyUsagePercent, 12.5)
+        let data = GrokUsageDataBuilder.combine(credits: credits, monthly: nil)
+        XCTAssertEqual(data.weekly?.percentage, 12.5)
+        XCTAssertNotNil(data.weekly?.resetsAt)
+    }
+
+    func testMonthlyFormatPercentage() throws {
+        let json = """
+        {
+          "config": {
+            "monthlyLimit": { "val": 150000 },
+            "used": { "val": 75000 },
+            "onDemandCap": { "val": 0 },
+            "billingPeriodStart": "2026-07-01T00:00:00+00:00",
+            "billingPeriodEnd": "2026-08-01T00:00:00+00:00"
+          }
+        }
+        """
+        let monthly = try JSONDecoder().decode(GrokMonthlyBillingResponse.self, from: Data(json.utf8))
+        let data = GrokUsageDataBuilder.combine(credits: nil, monthly: monthly)
+        XCTAssertEqual(data.monthly?.percentage ?? -1, 50, accuracy: 0.01)
+        XCTAssertEqual(data.monthly?.used, 75000)
+        XCTAssertEqual(data.monthly?.limit, 150000)
+        XCTAssertNotNil(data.monthly?.resetsAt)
+    }
+
+    func testCombineBothPayloads() throws {
+        let creditsJSON = """
+        {
+          "config": {
+            "currentPeriod": {
+              "type": "USAGE_PERIOD_TYPE_WEEKLY",
+              "start": "2026-07-21T00:00:00+00:00",
+              "end": "2026-07-28T00:00:00+00:00"
+            },
+            "creditUsagePercent": 2.0,
+            "productUsage": [{ "product": "GrokBuild", "usagePercent": 2.0 }],
+            "isUnifiedBillingUser": true,
+            "prepaidBalance": { "val": 10 }
+          }
+        }
+        """
+        let monthlyJSON = """
+        {
+          "config": {
+            "monthlyLimit": { "val": 100 },
+            "used": { "val": 25 },
+            "billingPeriodEnd": "2026-08-01T00:00:00+00:00"
+          }
+        }
+        """
+        let credits = try JSONDecoder().decode(GrokCreditsBillingResponse.self, from: Data(creditsJSON.utf8))
+        let monthly = try JSONDecoder().decode(GrokMonthlyBillingResponse.self, from: Data(monthlyJSON.utf8))
+        let data = GrokUsageDataBuilder.combine(credits: credits, monthly: monthly)
+        XCTAssertEqual(data.weekly?.percentage, 2.0)
+        XCTAssertEqual(data.monthly?.percentage ?? -1, 25, accuracy: 0.01)
+        XCTAssertTrue(data.credits?.enabled == true)
+        XCTAssertEqual(data.credits?.prepaidBalance, 10)
+    }
+
+    func testValNumberAcceptsIntAndString() throws {
+        let json = """
+        {
+          "config": {
+            "monthlyLimit": { "val": "200" },
+            "used": { "val": 50 }
+          }
+        }
+        """
+        let monthly = try JSONDecoder().decode(GrokMonthlyBillingResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(monthly.config?.monthlyLimit?.val, 200)
+        XCTAssertEqual(monthly.config?.used?.val, 50)
+    }
+
+    func testEmptyPayloadYieldsEmptyUsage() {
+        let data = GrokUsageDataBuilder.combine(credits: nil, monthly: nil)
+        XCTAssertNil(data.weekly)
+        XCTAssertNil(data.monthly)
+        XCTAssertNil(data.credits)
+    }
+}
+
+final class ProviderTypeGrokTests: XCTestCase {
+    func testProviderTypeIncludesGrok() {
+        XCTAssertEqual(ProviderType.grok.displayName, "Grok")
+        XCTAssertTrue(ProviderType.allCases.contains(.grok))
+    }
+}

--- a/Tests/Usage4ClaudeCoreTests/GrokUsageResponseTests.swift
+++ b/Tests/Usage4ClaudeCoreTests/GrokUsageResponseTests.swift
@@ -111,6 +111,148 @@ final class GrokUsageResponseTests: XCTestCase {
         XCTAssertNil(data.monthly)
         XCTAssertNil(data.credits)
     }
+
+    func testWeeklyFallsBackToCreditUsagePercentWhenProductUsageMissing() throws {
+        let json = """
+        {
+          "config": {
+            "currentPeriod": {
+              "type": "USAGE_PERIOD_TYPE_WEEKLY",
+              "start": "2026-07-21T00:00:00+00:00",
+              "end": "2026-07-28T00:00:00+00:00"
+            },
+            "creditUsagePercent": 33.0,
+            "isUnifiedBillingUser": true
+          }
+        }
+        """
+        let credits = try JSONDecoder().decode(GrokCreditsBillingResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(credits.weeklyUsagePercent, 33.0)
+        let data = GrokUsageDataBuilder.combine(credits: credits, monthly: nil)
+        XCTAssertEqual(data.weekly?.percentage, 33.0)
+    }
+
+    func testWeeklyPrefersGrokProductOverOtherProducts() throws {
+        let json = """
+        {
+          "config": {
+            "creditUsagePercent": 99.0,
+            "productUsage": [
+              { "product": "Other", "usagePercent": 50.0 },
+              { "product": "GrokBuild", "usagePercent": 7.0 }
+            ],
+            "currentPeriod": {
+              "end": "2026-07-28T00:00:00+00:00"
+            }
+          }
+        }
+        """
+        let credits = try JSONDecoder().decode(GrokCreditsBillingResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(credits.weeklyUsagePercent, 7.0)
+    }
+
+    func testZeroPercentWithoutEndDateIsNilWeekly() throws {
+        let json = """
+        {
+          "config": {
+            "creditUsagePercent": 0,
+            "productUsage": [{ "product": "GrokBuild", "usagePercent": 0 }]
+          }
+        }
+        """
+        let credits = try JSONDecoder().decode(GrokCreditsBillingResponse.self, from: Data(json.utf8))
+        let data = GrokUsageDataBuilder.combine(credits: credits, monthly: nil)
+        XCTAssertNil(data.weekly)
+    }
+
+    func testMonthlyMissingLimitOrUsedIsNil() throws {
+        let noLimit = """
+        { "config": { "used": { "val": 10 } } }
+        """
+        let noUsed = """
+        { "config": { "monthlyLimit": { "val": 100 } } }
+        """
+        let zeroLimit = """
+        { "config": { "monthlyLimit": { "val": 0 }, "used": { "val": 1 } } }
+        """
+        for json in [noLimit, noUsed, zeroLimit] {
+            let monthly = try JSONDecoder().decode(GrokMonthlyBillingResponse.self, from: Data(json.utf8))
+            let data = GrokUsageDataBuilder.combine(credits: nil, monthly: monthly)
+            XCTAssertNil(data.monthly, "expected nil monthly for \(json)")
+        }
+    }
+
+    func testClampsWeeklyPercentageToZeroHundred() throws {
+        let json = """
+        {
+          "config": {
+            "creditUsagePercent": 150,
+            "currentPeriod": { "end": "2026-07-28T00:00:00+00:00" }
+          }
+        }
+        """
+        let credits = try JSONDecoder().decode(GrokCreditsBillingResponse.self, from: Data(json.utf8))
+        let data = GrokUsageDataBuilder.combine(credits: credits, monthly: nil)
+        XCTAssertEqual(data.weekly?.percentage, 100)
+    }
+
+    func testDateParserAcceptsFractionalAndNonFractionalISO8601() {
+        let withFrac = GrokUsageDataBuilder.parseDate("2026-07-28T16:51:06.686549+00:00")
+        let withoutFrac = GrokUsageDataBuilder.parseDate("2026-07-28T16:51:06+00:00")
+        XCTAssertNotNil(withFrac)
+        XCTAssertNotNil(withoutFrac)
+        XCTAssertNil(GrokUsageDataBuilder.parseDate(nil))
+        XCTAssertNil(GrokUsageDataBuilder.parseDate(""))
+    }
+}
+
+final class GrokCreditsDataTests: XCTestCase {
+    func testEnabledWhenPrepaidBalancePositive() {
+        let c = GrokCreditsData(
+            prepaidBalance: 5,
+            onDemandCap: 0,
+            onDemandUsed: 0,
+            creditUsagePercent: nil,
+            isUnifiedBillingUser: false
+        )
+        XCTAssertTrue(c.enabled)
+        XCTAssertEqual(c.percentage, 0)
+    }
+
+    func testPercentageFromOnDemandUsedOverCap() {
+        let c = GrokCreditsData(
+            prepaidBalance: 0,
+            onDemandCap: 100,
+            onDemandUsed: 40,
+            creditUsagePercent: nil,
+            isUnifiedBillingUser: false
+        )
+        XCTAssertTrue(c.enabled)
+        XCTAssertEqual(c.percentage ?? -1, 40, accuracy: 0.01)
+    }
+
+    func testCreditUsagePercentTakesPriority() {
+        let c = GrokCreditsData(
+            prepaidBalance: 0,
+            onDemandCap: 100,
+            onDemandUsed: 40,
+            creditUsagePercent: 12,
+            isUnifiedBillingUser: true
+        )
+        XCTAssertEqual(c.percentage, 12)
+    }
+
+    func testDisabledWhenAllZero() {
+        let c = GrokCreditsData(
+            prepaidBalance: 0,
+            onDemandCap: 0,
+            onDemandUsed: 0,
+            creditUsagePercent: nil,
+            isUnifiedBillingUser: false
+        )
+        XCTAssertFalse(c.enabled)
+        XCTAssertNil(c.percentage)
+    }
 }
 
 final class ProviderTypeGrokTests: XCTestCase {

--- a/Usage4Claude/App/MenuBarIconRenderer.swift
+++ b/Usage4Claude/App/MenuBarIconRenderer.swift
@@ -41,6 +41,7 @@ class MenuBarIconRenderer {
     func createIcon(
         usageData: UsageData?,
         codexUsageData: CodexUsageData? = nil,
+        grokUsageData: GrokUsageData? = nil,
         hasUpdate: Bool,
         button: NSStatusBarButton?
     ) -> NSImage {
@@ -56,18 +57,62 @@ class MenuBarIconRenderer {
 
         var icon: NSImage
 
-        if let codex = codexUsageData {
-            // 有 Codex 数据路径
-            let allTypes = settings.getActiveDisplayTypes(usageData: usageData, codexUsageData: codex, forMenuBar: true)
-            let codexTypes = allTypes.filter { $0.provider == .codex }
+        // Prefer multi-provider composition when any non-Claude provider is present
+        if codexUsageData != nil || grokUsageData != nil {
+            let allTypes = settings.getActiveDisplayTypes(
+                usageData: usageData,
+                codexUsageData: codexUsageData,
+                grokUsageData: grokUsageData,
+                forMenuBar: true
+            )
+            var icons: [NSImage] = []
 
-            if settings.isMultiProviderActive, let data = usageData {
-                // 双 Provider 模式
+            if let data = usageData {
                 let claudeTypes = allTypes.filter { $0.provider == .claude }
-                icon = createMultiProviderIcon(data: data, codex: codex, claudeTypes: claudeTypes, codexTypes: codexTypes, isMonochrome: isMonochrome, button: button)
+                let claudeIcons = claudeTypes.compactMap {
+                    createIconForType($0, data: data, isMonochrome: isMonochrome, button: button)
+                }
+                if !claudeIcons.isEmpty {
+                    if settings.iconDisplayMode == .both || settings.iconDisplayMode == .iconOnly {
+                        let iconName = isMonochrome ? "AppIconReverse" : "AppIcon"
+                        if let copy = ImageHelper.createSquareIcon(named: iconName, size: providerBrandIconSize, isTemplate: isMonochrome) {
+                            icons.append(copy)
+                        }
+                    }
+                    if settings.iconDisplayMode != .iconOnly {
+                        icons.append(contentsOf: claudeIcons)
+                    }
+                }
+            }
+
+            if let codex = codexUsageData {
+                let codexTypes = allTypes.filter { $0.provider == .codex }
+                let codexIcons = buildCodexIcons(codex: codex, types: codexTypes, isMonochrome: isMonochrome, button: button)
+                if !codexIcons.isEmpty {
+                    if !icons.isEmpty, settings.iconDisplayMode == .percentageOnly {
+                        icons.append(createMenuBarDividerIcon(isMonochrome: isMonochrome))
+                    }
+                    icons.append(contentsOf: codexIcons)
+                }
+            }
+
+            if let grok = grokUsageData {
+                let grokTypes = allTypes.filter { $0.provider == .grok }
+                let grokIcons = buildGrokIcons(grok: grok, types: grokTypes, isMonochrome: isMonochrome, button: button)
+                if !grokIcons.isEmpty {
+                    if !icons.isEmpty, settings.iconDisplayMode == .percentageOnly {
+                        icons.append(createMenuBarDividerIcon(isMonochrome: isMonochrome))
+                    }
+                    icons.append(contentsOf: grokIcons)
+                }
+            }
+
+            if icons.isEmpty {
+                icon = createSimpleCircleIcon()
+            } else if icons.count == 1 {
+                icon = icons[0]
             } else {
-                // Codex-only（无 Claude 账号）或降级路径
-                icon = createCodexOnlyIcon(codex: codex, codexTypes: codexTypes, isMonochrome: isMonochrome, button: button)
+                icon = combineIcons(icons)
             }
         } else {
             // Claude-only 路径（原有逻辑）
@@ -227,6 +272,26 @@ class MenuBarIconRenderer {
         case .codex:
             let iconName = isMonochrome ? "CodexIconReverse" : "CodexIcon"
             return ImageHelper.createSquareIcon(named: iconName, size: size, isTemplate: isMonochrome, sourceInset: isMonochrome ? 0 : 2)
+        case .grok:
+            // No asset yet — synthesize a simple SF-symbol-like circle badge via template text
+            let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+                let color: NSColor = isMonochrome ? .labelColor : NSColor(red: 100/255, green: 116/255, blue: 139/255, alpha: 1)
+                color.setStroke()
+                let inset = rect.insetBy(dx: 1.5, dy: 1.5)
+                let path = NSBezierPath(ovalIn: inset)
+                path.lineWidth = 1.5
+                path.stroke()
+                let attrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: size * 0.45, weight: .bold),
+                    .foregroundColor: color
+                ]
+                let str = NSString(string: "G")
+                let s = str.size(withAttributes: attrs)
+                str.draw(at: NSPoint(x: rect.midX - s.width/2, y: rect.midY - s.height/2), withAttributes: attrs)
+                return true
+            }
+            image.isTemplate = isMonochrome
+            return image
         }
     }
 
@@ -577,9 +642,9 @@ class MenuBarIconRenderer {
             guard let percentage = percentage else { return nil }
             return ShapeIconRenderer.createHexagonIcon(percentage: percentage, isMonochrome: isMonochrome, button: button, removeBackground: removeBackground)
 
-        case .codexPrimary, .codexSecondary, .codexExtraUsage:
-            // Codex 数据在 Phase 4 通过 createCodexIcon 独立渲染
-            // createIconForType 仅处理 Claude UsageData，此处返回 nil
+        case .codexPrimary, .codexSecondary, .codexExtraUsage,
+             .grokWeekly, .grokMonthly, .grokCredits:
+            // Codex / Grok data rendered via dedicated icon builders
             return nil
         }
     }
@@ -612,8 +677,41 @@ class MenuBarIconRenderer {
             let color = UsageColorScheme.codexExtraUsageColorAdaptive(percentage, for: button)
             return ShapeIconRenderer.createHexagonIcon(percentage: percentage, isMonochrome: isMonochrome, button: button, removeBackground: removeBackground, colorOverride: color)
 
+        case .grokWeekly:
+            if isMonochrome {
+                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: 18, height: 18), button: button, removeBackground: true)
+            }
+            let color = UsageColorScheme.grokWeeklyColorAdaptive(percentage, for: button)
+            return createCircleImage(percentage: percentage, size: NSSize(width: 18, height: 18), colorOverride: color, button: button, removeBackground: removeBackground)
+
+        case .grokMonthly:
+            if isMonochrome {
+                return createCircleTemplateImage(percentage: percentage, size: NSSize(width: 18, height: 18), useSevenDayStyle: true, button: button, removeBackground: true)
+            }
+            let color = UsageColorScheme.grokMonthlyColorAdaptive(percentage, for: button)
+            return createCircleImage(percentage: percentage, size: NSSize(width: 18, height: 18), colorOverride: color, useDashedStyle: true, button: button, removeBackground: removeBackground)
+
+        case .grokCredits:
+            let color = UsageColorScheme.grokCreditsColorAdaptive(percentage, for: button)
+            return ShapeIconRenderer.createHexagonIcon(percentage: percentage, isMonochrome: isMonochrome, button: button, removeBackground: removeBackground, colorOverride: color)
+
         default:
             return nil
+        }
+    }
+
+    /// Build Grok menu-bar icons for active Grok limit types
+    func buildGrokIcons(grok: GrokUsageData, types: [LimitType], isMonochrome: Bool, button: NSStatusBarButton?) -> [NSImage] {
+        types.compactMap { type -> NSImage? in
+            let percentage: Double?
+            switch type {
+            case .grokWeekly: percentage = grok.weekly?.percentage
+            case .grokMonthly: percentage = grok.monthly?.percentage
+            case .grokCredits: percentage = grok.credits?.percentage
+            default: percentage = nil
+            }
+            guard let percentage else { return nil }
+            return createCodexIcon(type: type, percentage: percentage, isMonochrome: isMonochrome, button: button)
         }
     }
 

--- a/Usage4Claude/App/MenuBarManager.swift
+++ b/Usage4Claude/App/MenuBarManager.swift
@@ -61,12 +61,16 @@ class MenuBarManager: ObservableObject {
     @Published var usageData: UsageData?
     /// Codex 用量数据（从 dataManager 同步）
     @Published var codexUsageData: CodexUsageData?
+    /// Grok 用量数据（从 dataManager 同步）
+    @Published var grokUsageData: GrokUsageData?
     /// 加载状态（从 dataManager 同步）
     @Published var isLoading = false
     /// 错误消息（从 dataManager 同步）
     @Published var errorMessage: String?
     /// Codex 错误消息（独立于 Claude）
     @Published var codexErrorMessage: String?
+    /// Grok 错误消息
+    @Published var grokErrorMessage: String?
     /// Codex 三级刷新均失败，需要用户手动重新登录
     @Published var codexNeedsRelogin = false
     /// 是否有可用更新（由 Sparkle 的 SPUUpdaterDelegate 回调驱动）
@@ -112,6 +116,13 @@ class MenuBarManager: ObservableObject {
             }
             .store(in: &cancellables)
 
+        dataManager.$grokUsageData
+            .sink { [weak self] data in
+                self?.grokUsageData = data
+                self?.updateMenuBarIcon()
+            }
+            .store(in: &cancellables)
+
         dataManager.$isLoading
             .assign(to: &$isLoading)
 
@@ -120,6 +131,9 @@ class MenuBarManager: ObservableObject {
 
         dataManager.$codexErrorMessage
             .assign(to: &$codexErrorMessage)
+
+        dataManager.$grokErrorMessage
+            .assign(to: &$grokErrorMessage)
 
         dataManager.$codexNeedsRelogin
             .assign(to: &$codexNeedsRelogin)
@@ -178,6 +192,8 @@ class MenuBarManager: ObservableObject {
             dataManager.handleClaudeOnlyRefresh()
         case .refreshCodex:
             dataManager.handleCodexOnlyRefresh()
+        case .refreshGrok:
+            dataManager.handleGrokOnlyRefresh()
         case .generalSettings:
             closePopover()
             openSettingsWindow(tab: 0)
@@ -330,6 +346,10 @@ class MenuBarManager: ObservableObject {
                 get: { self.codexUsageData },
                 set: { self.codexUsageData = $0 }
             ),
+            grokUsageData: Binding(
+                get: { self.grokUsageData },
+                set: { self.grokUsageData = $0 }
+            ),
             errorMessage: Binding(
                 get: { self.errorMessage },
                 set: { self.errorMessage = $0 }
@@ -337,6 +357,10 @@ class MenuBarManager: ObservableObject {
             codexErrorMessage: Binding(
                 get: { self.codexErrorMessage },
                 set: { self.codexErrorMessage = $0 }
+            ),
+            grokErrorMessage: Binding(
+                get: { self.grokErrorMessage },
+                set: { self.grokErrorMessage = $0 }
             ),
             codexNeedsRelogin: Binding(
                 get: { self.codexNeedsRelogin },
@@ -573,7 +597,13 @@ class MenuBarManager: ObservableObject {
 
     /// 更新菜单栏图标
     private func updateMenuBarIcon() {
-        ui.updateMenuBarIcon(usageData: usageData, codexUsageData: codexUsageData, hasUpdate: hasAvailableUpdate, shouldShowBadge: shouldShowUpdateBadge)
+        ui.updateMenuBarIcon(
+            usageData: usageData,
+            codexUsageData: codexUsageData,
+            grokUsageData: grokUsageData,
+            hasUpdate: hasAvailableUpdate,
+            shouldShowBadge: shouldShowUpdateBadge
+        )
     }
     
     // MARK: - Cleanup

--- a/Usage4Claude/App/MenuBarUI.swift
+++ b/Usage4Claude/App/MenuBarUI.swift
@@ -544,14 +544,25 @@ class MenuBarUI {
     ///   - codexUsageData: Codex 用量数据
     ///   - hasUpdate: 是否有可用更新
     ///   - shouldShowBadge: 是否显示更新徽章
-    func updateMenuBarIcon(usageData: UsageData?, codexUsageData: CodexUsageData? = nil, hasUpdate: Bool, shouldShowBadge: Bool) {
+    func updateMenuBarIcon(
+        usageData: UsageData?,
+        codexUsageData: CodexUsageData? = nil,
+        grokUsageData: GrokUsageData? = nil,
+        hasUpdate: Bool,
+        shouldShowBadge: Bool
+    ) {
         guard let button = statusItem.button else { return }
 
         // 确定是否实际显示徽章
         let showBadge = hasUpdate && shouldShowBadge
 
         // 生成缓存键
-        let cacheKey = generateCacheKey(usageData: usageData, codexUsageData: codexUsageData, hasUpdate: showBadge)
+        let cacheKey = generateCacheKey(
+            usageData: usageData,
+            codexUsageData: codexUsageData,
+            grokUsageData: grokUsageData,
+            hasUpdate: showBadge
+        )
 
         // 尝试从缓存获取
         if let cachedImage = iconCache[cacheKey] {
@@ -563,6 +574,7 @@ class MenuBarUI {
         let icon = iconRenderer.createIcon(
             usageData: usageData,
             codexUsageData: codexUsageData,
+            grokUsageData: grokUsageData,
             hasUpdate: showBadge,
             button: button
         )
@@ -590,7 +602,12 @@ class MenuBarUI {
     ///   - codexUsageData: Codex 用量数据
     ///   - hasUpdate: 是否有更新徽章
     /// - Returns: 缓存键字符串
-    private func generateCacheKey(usageData: UsageData?, codexUsageData: CodexUsageData? = nil, hasUpdate: Bool) -> String {
+    private func generateCacheKey(
+        usageData: UsageData?,
+        codexUsageData: CodexUsageData? = nil,
+        grokUsageData: GrokUsageData? = nil,
+        hasUpdate: Bool
+    ) -> String {
         let isMulti = settings.isMultiProviderActive
         guard let data = usageData else {
             var key = "no_data_\(settings.iconDisplayMode.rawValue)_\(settings.iconStyleMode.rawValue)_\(settings.displayMode.rawValue)_mp\(isMulti)"
@@ -622,6 +639,11 @@ class MenuBarUI {
                     key += "_cxenil"
                 }
             }
+            if let grok = grokUsageData {
+                if let w = grok.weekly { key += "_gkw\(Int(w.percentage))" }
+                if let m = grok.monthly { key += "_gkm\(Int(m.percentage))" }
+                if let c = grok.credits?.percentage { key += "_gkc\(Int(c))" }
+            }
 
             if hasUpdate {
                 key += "_badge"
@@ -652,6 +674,11 @@ class MenuBarUI {
             if let p = codex.primary { key += "_cxp\(Int(p.percentage))" }
             if let s = codex.secondary { key += "_cxs\(Int(s.percentage))" }
             if let e = codex.extraUsage?.percentage { key += "_cxe\(Int(e))" }
+        }
+        if let grok = grokUsageData {
+            if let w = grok.weekly { key += "_gkw\(Int(w.percentage))" }
+            if let m = grok.monthly { key += "_gkm\(Int(m.percentage))" }
+            if let c = grok.credits?.percentage { key += "_gkc\(Int(c))" }
         }
 
         if hasUpdate {

--- a/Usage4Claude/Helpers/ColorScheme.swift
+++ b/Usage4Claude/Helpers/ColorScheme.swift
@@ -321,6 +321,88 @@ enum UsageColorScheme {
         }
     }
 
+    // MARK: - Grok Weekly 配色（黑/灰 → 深灰，圆形）
+
+    /// Grok brand-adjacent grays with warm warning ramp
+    static func grokWeeklyColor(_ percentage: Double) -> NSColor {
+        if percentage < 70 {
+            return NSColor(red: 100/255.0, green: 116/255.0, blue: 139/255.0, alpha: 1.0)  // #64748B slate
+        } else if percentage < 90 {
+            return NSColor(red: 71/255.0, green: 85/255.0, blue: 105/255.0, alpha: 1.0)    // #475569
+        } else {
+            return NSColor(red: 30/255.0, green: 41/255.0, blue: 59/255.0, alpha: 1.0)     // #1E293B
+        }
+    }
+
+    static func grokWeeklyColorSwiftUI(_ percentage: Double, opacity: Double = 0.9) -> Color {
+        if percentage < 70 {
+            return Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0).opacity(opacity)
+        } else if percentage < 90 {
+            return Color(red: 71/255.0, green: 85/255.0, blue: 105/255.0).opacity(opacity)
+        } else {
+            return Color(red: 30/255.0, green: 41/255.0, blue: 59/255.0).opacity(opacity)
+        }
+    }
+
+    static func grokWeeklyColorAdaptive(_ percentage: Double, for statusButton: NSStatusBarButton? = nil) -> NSColor {
+        let baseColor = grokWeeklyColor(percentage)
+        return isDarkMode(for: statusButton) ? baseColor.adjustedForDarkMode() : baseColor
+    }
+
+    // MARK: - Grok Monthly 配色（品红/玫红，虚线圆）
+
+    static func grokMonthlyColor(_ percentage: Double) -> NSColor {
+        if percentage < 70 {
+            return NSColor(red: 244/255.0, green: 114/255.0, blue: 182/255.0, alpha: 1.0)  // #F472B6
+        } else if percentage < 90 {
+            return NSColor(red: 219/255.0, green: 39/255.0, blue: 119/255.0, alpha: 1.0)   // #DB2777
+        } else {
+            return NSColor(red: 131/255.0, green: 24/255.0, blue: 67/255.0, alpha: 1.0)    // #831843
+        }
+    }
+
+    static func grokMonthlyColorSwiftUI(_ percentage: Double, opacity: Double = 0.9) -> Color {
+        if percentage < 70 {
+            return Color(red: 244/255.0, green: 114/255.0, blue: 182/255.0).opacity(opacity)
+        } else if percentage < 90 {
+            return Color(red: 219/255.0, green: 39/255.0, blue: 119/255.0).opacity(opacity)
+        } else {
+            return Color(red: 131/255.0, green: 24/255.0, blue: 67/255.0).opacity(opacity)
+        }
+    }
+
+    static func grokMonthlyColorAdaptive(_ percentage: Double, for statusButton: NSStatusBarButton? = nil) -> NSColor {
+        let baseColor = grokMonthlyColor(percentage)
+        return isDarkMode(for: statusButton) ? baseColor.adjustedForDarkMode() : baseColor
+    }
+
+    // MARK: - Grok Credits 配色（冷金/柠檬，六边形）
+
+    static func grokCreditsColor(_ percentage: Double) -> NSColor {
+        if percentage < 70 {
+            return NSColor(red: 250/255.0, green: 204/255.0, blue: 21/255.0, alpha: 1.0)   // #FACC15
+        } else if percentage < 90 {
+            return NSColor(red: 202/255.0, green: 138/255.0, blue: 4/255.0, alpha: 1.0)    // #CA8A04
+        } else {
+            return NSColor(red: 113/255.0, green: 63/255.0, blue: 18/255.0, alpha: 1.0)    // #713F12
+        }
+    }
+
+    static func grokCreditsColorSwiftUI(_ percentage: Double, opacity: Double = 0.9) -> Color {
+        if percentage < 70 {
+            return Color(red: 250/255.0, green: 204/255.0, blue: 21/255.0).opacity(opacity)
+        } else if percentage < 90 {
+            return Color(red: 202/255.0, green: 138/255.0, blue: 4/255.0).opacity(opacity)
+        } else {
+            return Color(red: 113/255.0, green: 63/255.0, blue: 18/255.0).opacity(opacity)
+        }
+    }
+
+    static func grokCreditsColorAdaptive(_ percentage: Double, for statusButton: NSStatusBarButton? = nil) -> NSColor {
+        let baseColor = grokCreditsColor(percentage)
+        return isDarkMode(for: statusButton) ? baseColor.adjustedForDarkMode() : baseColor
+    }
+
     // MARK: - 备选配色方案（注释保留，方便切换测试）
 
     /*

--- a/Usage4Claude/Helpers/DataRefreshManager.swift
+++ b/Usage4Claude/Helpers/DataRefreshManager.swift
@@ -21,6 +21,8 @@ class DataRefreshManager: ObservableObject {
     private let apiService = ClaudeAPIService()
     /// Codex API 服务实例
     private let codexApiService = CodexAPIService()
+    /// Grok API 服务实例
+    private let grokApiService = GrokAPIService()
     /// 定时器管理器
     private let timerManager = TimerManager()
     /// 用户设置实例
@@ -32,12 +34,16 @@ class DataRefreshManager: ObservableObject {
     @Published var usageData: UsageData?
     /// Codex 用量数据（nil 表示无 Codex 账号或拉取失败）
     @Published var codexUsageData: CodexUsageData?
+    /// Grok 用量数据
+    @Published var grokUsageData: GrokUsageData?
     /// 加载状态
     @Published var isLoading = false
     /// 错误消息
     @Published var errorMessage: String?
     /// Codex 错误消息（独立于 Claude，避免双 Provider 时被静默隐藏）
     @Published var codexErrorMessage: String?
+    /// Grok 错误消息
+    @Published var grokErrorMessage: String?
     /// 刷新状态管理器
     let refreshState = RefreshState()
 
@@ -47,6 +53,8 @@ class DataRefreshManager: ObservableObject {
     private var lastResetsAt: Date?
     /// Codex 上次的重置时间
     private var lastCodexResetsAt: Date?
+    /// Grok 上次的重置时间
+    private var lastGrokResetsAt: Date?
     /// 上次手动刷新时间
     private var lastManualRefreshTime: Date?
     /// 上次API请求时间
@@ -109,6 +117,28 @@ class DataRefreshManager: ObservableObject {
         #endif
     }
 
+    private var shouldSuppressDebugGrokUsageForDisplayOptions: Bool {
+        #if DEBUG
+        return settings.debugModeEnabled
+            && settings.displayMode == .custom
+            && !settings.customDisplayMenuBarOnly
+            && !settings.customDisplayTypes.contains { $0.provider == .grok }
+        #else
+        return false
+        #endif
+    }
+
+    private var shouldFetchGrokUsage: Bool {
+        #if DEBUG
+        if shouldSuppressDebugGrokUsageForDisplayOptions {
+            return false
+        }
+        return settings.debugModeEnabled || settings.hasValidGrokCredentials
+        #else
+        return settings.hasValidGrokCredentials
+        #endif
+    }
+
     /// 定时器标识符统一定义在 TimerManager.Identifier，避免两处各自为政
     private typealias TimerID = TimerManager.Identifier
 
@@ -120,15 +150,17 @@ class DataRefreshManager: ObservableObject {
 
     // MARK: - Data Fetching
 
-    /// 获取用量数据（Claude + Codex 并发）
+    /// 获取用量数据（Claude + Codex + Grok 并发）
     func fetchUsage() {
         isLoading = true
         errorMessage = nil
         codexErrorMessage = nil
+        grokErrorMessage = nil
         lastAPIFetchTime = Date()
 
         let fetchClaude = shouldFetchClaudeUsage
         let fetchCodex = shouldFetchCodexUsage
+        let fetchGrok = shouldFetchGrokUsage
 
         if !fetchClaude {
             clearClaudeUsageState()
@@ -136,24 +168,29 @@ class DataRefreshManager: ObservableObject {
         if !fetchCodex {
             clearCodexUsageState()
         }
+        if !fetchGrok {
+            clearGrokUsageState()
+        }
 
-        guard fetchClaude || fetchCodex else {
+        guard fetchClaude || fetchCodex || fetchGrok else {
             isLoading = false
             endRefreshAnimationWithMinimumDuration { }
             errorMessage = UsageError.noCredentials.localizedDescription
             return
         }
 
-        // Claude 与 Codex 并发拉取：两个子任务立即启动，结果在 MainActor 上顺序 await 合并
-        // （审计报告 4.2：替代 DispatchGroup + 跨线程共享可变结果变量的旧写法）
+        // Claude / Codex / Grok 并发拉取：子任务立即启动，结果在 MainActor 上合并
         let claudeTask: Task<Result<UsageData, Error>, Never>? =
             fetchClaude ? Task { await self.apiService.fetchUsageResult() } : nil
         let codexTask: Task<Result<CodexUsageData, Error>, Never>? =
             fetchCodex ? Task { await self.codexApiService.fetchUsageResult() } : nil
+        let grokTask: Task<Result<GrokUsageData, Error>, Never>? =
+            fetchGrok ? Task { await self.grokApiService.fetchUsageResult() } : nil
 
         Task { @MainActor [weak self] in
             let claudeResult = await claudeTask?.value
             let codexResult = await codexTask?.value
+            let grokResult = await grokTask?.value
 
             guard let self = self else { return }
             self.isLoading = false
@@ -182,6 +219,26 @@ class DataRefreshManager: ObservableObject {
                 }
             } else {
                 self.clearCodexUsageState()
+            }
+
+            if fetchGrok {
+                switch grokResult {
+                case .success(let grok):
+                    if let utilization = self.monitoringUtilization(for: grok) {
+                        monitoringUtilizations[.grok] = utilization
+                    }
+                    self.processGrokSuccess(grok)
+
+                case .failure(let error):
+                    Logger.menuBar.info("Grok request failed: \(error.localizedDescription)")
+                    self.grokErrorMessage = error.localizedDescription
+                    self.clearGrokUsageState(clearError: false)
+
+                case .none:
+                    self.clearGrokUsageState()
+                }
+            } else {
+                self.clearGrokUsageState()
             }
 
             // 处理 Claude 结果
@@ -234,6 +291,14 @@ class DataRefreshManager: ObservableObject {
         cancelCodexResetVerification()
     }
 
+    private func clearGrokUsageState(clearError: Bool = true) {
+        grokUsageData = nil
+        if clearError {
+            grokErrorMessage = nil
+        }
+        lastGrokResetsAt = nil
+    }
+
     private func monitoringUtilization(for codex: CodexUsageData) -> Double? {
         [
             codex.primary?.percentage,
@@ -242,6 +307,56 @@ class DataRefreshManager: ObservableObject {
         ]
         .compactMap { $0 }
         .max()
+    }
+
+    private func monitoringUtilization(for grok: GrokUsageData) -> Double? {
+        [
+            grok.weekly?.percentage,
+            grok.monthly?.percentage,
+            grok.credits?.percentage
+        ]
+        .compactMap { $0 }
+        .max()
+    }
+
+    private func processGrokSuccess(_ data: GrokUsageData) {
+        let previous = grokUsageData
+        grokUsageData = data
+        grokErrorMessage = nil
+        if let utilization = monitoringUtilization(for: data) {
+            settings.updateSmartMonitoringMode(providerUtilizations: [.grok: utilization])
+        }
+        if settings.notificationsEnabled {
+            NotificationManager.shared.checkAndNotify(grokUsageData: data, previousData: previous)
+        }
+        let newResetsAt = data.weekly?.resetsAt ?? data.monthly?.resetsAt
+        lastGrokResetsAt = newResetsAt
+    }
+
+    /// Grok-only refresh
+    func fetchGrokOnly() {
+        guard shouldFetchGrokUsage else {
+            clearGrokUsageState()
+            return
+        }
+        isLoading = true
+        grokErrorMessage = nil
+        lastAPIFetchTime = Date()
+        grokApiService.fetchUsage { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.isLoading = false
+                self.endRefreshAnimationWithMinimumDuration { }
+                switch result {
+                case .success(let data):
+                    self.processGrokSuccess(data)
+                case .failure(let error):
+                    self.grokErrorMessage = error.localizedDescription
+                    self.clearGrokUsageState(clearError: false)
+                    Logger.menuBar.info("Grok request failed: \(error.localizedDescription)")
+                }
+            }
+        }
     }
 
     /// 开始数据刷新
@@ -451,6 +566,26 @@ class DataRefreshManager: ObservableObject {
         fetchCodexOnly()
     }
 
+    /// Grok-only refresh (ring click)
+    func handleGrokOnlyRefresh() {
+        guard shouldFetchGrokUsage else {
+            clearGrokUsageState()
+            return
+        }
+        let now = Date()
+        if let lastManual = lastManualRefreshTime,
+           now.timeIntervalSince(lastManual) < 10 { return }
+        lastManualRefreshTime = now
+        refreshAnimationStartTime = now
+        refreshState.refreshingProvider = .grok
+        refreshState.isRefreshing = true
+        refreshState.canRefresh = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+            self?.refreshState.canRefresh = true
+        }
+        fetchGrokOnly()
+    }
+
     private func fetchClaudeOnly() {
         guard shouldFetchClaudeUsage else {
             clearClaudeUsageState()
@@ -657,9 +792,17 @@ class DataRefreshManager: ObservableObject {
                 fetchCodexOnly()
             }
 
+        case .grok:
+            grokApiService.clearAccessTokenCache()
+            clearGrokUsageState()
+            if shouldFetchGrokUsage {
+                fetchGrokOnly()
+            }
+
         case .none:
             clearClaudeUsageState()
             clearCodexUsageState()
+            clearGrokUsageState()
             NotificationManager.shared.resetAllNotificationStates()
             fetchUsage()
         }

--- a/Usage4Claude/Helpers/IconShapePaths.swift
+++ b/Usage4Claude/Helpers/IconShapePaths.swift
@@ -118,7 +118,7 @@ struct IconShapePaths {
         let hexRadius = min(rect.width, rect.height) / 2 - 3
 
         switch type {
-        case .fiveHour, .sevenDay, .codexPrimary, .codexSecondary:
+        case .fiveHour, .sevenDay, .codexPrimary, .codexSecondary, .grokWeekly, .grokMonthly:
             return circlePath(in: rect)
 
         case .opusWeekly:
@@ -127,7 +127,7 @@ struct IconShapePaths {
         case .sonnetWeekly:
             return chamferedSquarePath(in: rect)
 
-        case .extraUsage, .codexExtraUsage:
+        case .extraUsage, .codexExtraUsage, .grokCredits:
             return hexagonPath(center: center, radius: hexRadius)
         }
     }

--- a/Usage4Claude/Helpers/LocalizationHelper.swift
+++ b/Usage4Claude/Helpers/LocalizationHelper.swift
@@ -52,6 +52,16 @@ enum L {
         static var codexAccounts: String { localized("account.codex_accounts") }
         static var addCodexAccount: String { localized("account.add_codex_account") }
         static var codexCurrentAccount: String { localized("account.codex_current_account") }
+        static var grokAccounts: String { localized("account.grok_accounts") }
+        static var grokCurrentAccount: String { localized("account.grok_current_account") }
+        static var importGrokAuth: String { localized("account.import_grok_auth") }
+        static var importGrokAuthHelp: String { localized("account.import_grok_auth_help") }
+        static var grokDeviceLogin: String { localized("account.grok_device_login") }
+        static var grokDeviceLoginHelp: String { localized("account.grok_device_login_help") }
+        static var grokDeviceCodeHint: String { localized("account.grok_device_code_hint") }
+        static var grokOpenBrowser: String { localized("account.grok_open_browser") }
+        static var grokDevicePreparing: String { localized("account.grok_device_preparing") }
+        static var grokImportSuccess: String { localized("account.grok_import_success") }
     }
     
     // MARK: - Usage Detail View
@@ -76,6 +86,7 @@ enum L {
         static var runDiagnostic: String { localized("usage.run_diagnostic") }
         static var codexTitle: String { localized("usage.codex_title") }
         static var codexRelogin: String { localized("usage.codex_relogin") }
+        static var grokTitle: String { localized("usage.grok_title") }
     }
     
     // MARK: - Settings Tabs
@@ -247,6 +258,9 @@ enum L {
         static var codexPrimary: String { localized("codex_primary_limit") }
         static var codexSecondary: String { localized("codex_secondary_limit") }
         static var codexExtraUsage: String { localized("codex_extra_usage") }
+        static var grokWeekly: String { localized("grok_weekly_limit") }
+        static var grokMonthly: String { localized("grok_monthly_limit") }
+        static var grokCredits: String { localized("grok_credits") }
     }
 
     // MARK: - Detail Rows
@@ -387,6 +401,9 @@ enum L {
         static var codexPrimary: String { localized("codex_primary_limit") }
         static var codexSecondary: String { localized("codex_secondary_limit") }
         static var codexExtraUsage: String { localized("codex_extra_usage") }
+        static var grokWeekly: String { localized("grok_weekly_limit") }
+        static var grokMonthly: String { localized("grok_monthly_limit") }
+        static var grokCredits: String { localized("grok_credits") }
     }
 
     // MARK: - Display Options (v2.0.0)

--- a/Usage4Claude/Models/AccountStore.swift
+++ b/Usage4Claude/Models/AccountStore.swift
@@ -12,7 +12,7 @@ import Foundation
 import Combine
 import OSLog
 
-/// 多账户（Claude + Codex）存储、持久化与切换逻辑
+/// 多账户（Claude + Codex + Grok）存储、持久化与切换逻辑
 final class AccountStore: ObservableObject {
 
     private let defaults = UserDefaults.standard
@@ -119,6 +119,47 @@ final class AccountStore: ObservableObject {
         !codexSessionToken.isEmpty
     }
 
+    // MARK: - Grok 账户
+
+    /// Grok 账户列表（独立 Keychain key "accounts_grok"）
+    @Published var grokAccounts: [Account] {
+        didSet {
+            saveGrokAccounts()
+        }
+    }
+
+    /// 当前激活的 Grok 账户 ID
+    @Published var currentGrokAccountId: UUID? {
+        didSet {
+            #if DEBUG
+            let key = "DEBUG_currentGrokAccountId"
+            #else
+            let key = "currentGrokAccountId"
+            #endif
+            if let id = currentGrokAccountId {
+                defaults.set(id.uuidString, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+    }
+
+    /// 当前激活的 Grok 账户
+    var currentGrokAccount: Account? {
+        guard let id = currentGrokAccountId else { return grokAccounts.first }
+        return grokAccounts.first { $0.id == id } ?? grokAccounts.first
+    }
+
+    /// Grok OIDC refresh_token（存于 Account.sessionKey）
+    var grokRefreshToken: String {
+        currentGrokAccount?.sessionKey ?? ""
+    }
+
+    /// Grok 认证是否已配置
+    var hasValidGrokCredentials: Bool {
+        !grokRefreshToken.isEmpty
+    }
+
     // MARK: - Initialization
 
     init() {
@@ -195,6 +236,23 @@ final class AccountStore: ObservableObject {
             self.currentCodexAccountId = id
         } else {
             self.currentCodexAccountId = loadedCodexAccounts.first?.id
+        }
+
+        // MARK: - 加载 Grok 账户数据
+
+        let loadedGrokAccounts = keychain.loadGrokAccounts() ?? []
+        self.grokAccounts = loadedGrokAccounts
+
+        #if DEBUG
+        let grokCurrentAccountIdKey = "DEBUG_currentGrokAccountId"
+        #else
+        let grokCurrentAccountIdKey = "currentGrokAccountId"
+        #endif
+        if let idString = defaults.string(forKey: grokCurrentAccountIdKey),
+           let id = UUID(uuidString: idString) {
+            self.currentGrokAccountId = id
+        } else {
+            self.currentGrokAccountId = loadedGrokAccounts.first?.id
         }
 
         // MARK: - 旧版迁移（v1.x → v2.0.0，保留向后兼容）
@@ -382,6 +440,87 @@ final class AccountStore: ObservableObject {
         // Account 是 struct，下标赋值触发 codexAccounts.didSet → saveCodexAccounts()，自动持久化
         codexAccounts[index].sessionKey = token
         Logger.settings.notice("Codex session-token 已静默更新（自动续期）")
+    }
+
+    // MARK: - Grok Account Management
+
+    private func saveGrokAccounts() {
+        let snapshot = grokAccounts
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.keychain.saveGrokAccounts(snapshot)
+        }
+    }
+
+    /// 添加/更新 Grok 账户
+    @discardableResult
+    func addGrokAccount(_ account: Account) -> (account: Account, wasFirstGrokAccount: Bool) {
+        let stableId = account.organizationId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let existingIndex = grokAccounts.firstIndex { existing in
+            if !stableId.isEmpty {
+                let existingStableId = existing.organizationId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                return existingStableId == stableId || existing.sessionKey == account.sessionKey
+            }
+            return existing.sessionKey == account.sessionKey
+        }
+
+        if let index = existingIndex {
+            grokAccounts[index].sessionKey = account.sessionKey
+            grokAccounts[index].organizationId = account.organizationId
+            grokAccounts[index].organizationName = account.organizationName
+            grokAccounts[index].provider = .grok
+            if currentGrokAccountId == nil {
+                currentGrokAccountId = grokAccounts[index].id
+            }
+            Logger.settings.notice("Updated existing Grok account: \(self.grokAccounts[index].displayName)")
+            postAccountChanged(provider: .grok)
+            return (grokAccounts[index], false)
+        }
+
+        let wasFirst = grokAccounts.isEmpty
+        var stored = account
+        stored.provider = .grok
+        grokAccounts.append(stored)
+        if grokAccounts.count == 1 {
+            currentGrokAccountId = stored.id
+        }
+        Logger.settings.notice("Added Grok account: \(stored.displayName)")
+        postAccountChanged(provider: .grok)
+        return (stored, wasFirst)
+    }
+
+    func removeGrokAccount(_ account: Account) {
+        guard let index = grokAccounts.firstIndex(where: { $0.id == account.id }) else { return }
+        let wasCurrent = (currentGrokAccountId == account.id)
+        grokAccounts.remove(at: index)
+        NotificationManager.shared.resetNotificationStates(for: .grok, accountId: account.id)
+        if wasCurrent {
+            currentGrokAccountId = grokAccounts.first?.id
+            postAccountChanged(provider: .grok)
+        }
+        Logger.settings.notice("Removed Grok account: \(account.displayName)")
+    }
+
+    func switchToGrokAccount(_ account: Account) {
+        guard account.id != currentGrokAccountId else { return }
+        guard grokAccounts.contains(where: { $0.id == account.id }) else { return }
+        currentGrokAccountId = account.id
+        Logger.settings.notice("Switched to Grok account: \(account.displayName)")
+        postAccountChanged(provider: .grok)
+    }
+
+    func updateGrokAccount(_ account: Account, alias: String?) {
+        guard let index = grokAccounts.firstIndex(where: { $0.id == account.id }) else { return }
+        grokAccounts[index].alias = alias
+        Logger.settings.notice("Updated Grok account alias: \(self.grokAccounts[index].displayName)")
+    }
+
+    /// Silently update current Grok refresh_token (token rotation; no accountChanged)
+    func silentlyUpdateCurrentGrokRefreshToken(_ token: String) {
+        guard let id = currentGrokAccountId,
+              let index = grokAccounts.firstIndex(where: { $0.id == id }) else { return }
+        guard grokAccounts[index].sessionKey != token else { return }
+        grokAccounts[index].sessionKey = token
+        Logger.settings.notice("Grok refresh_token silently updated (auto-renewal)")
     }
 
     // MARK: - Shared Helpers

--- a/Usage4Claude/Models/DiagnosticReport.swift
+++ b/Usage4Claude/Models/DiagnosticReport.swift
@@ -145,6 +145,7 @@ struct DiagnosticReport: Codable {
         switch result.providerType {
         case .claude: title = "## Claude Diagnostic"
         case .codex: title = "## Codex (ChatGPT) Diagnostic"
+        case .grok: title = "## Grok Diagnostic"
         }
 
         var section = "\n\(title)\n\n"

--- a/Usage4Claude/Models/GrokUsageData.swift
+++ b/Usage4Claude/Models/GrokUsageData.swift
@@ -1,0 +1,273 @@
+//
+//  GrokUsageData.swift
+//  Usage4Claude
+//
+//  Pure-data types + parsing for Grok Build billing/usage responses from
+//  https://cli-chat-proxy.grok.com/v1/billing (?format=credits for weekly
+//  subscription quota; default form for monthly included allowance).
+//  Lives here (not Helpers/) so it can be cherry-picked into a SwiftPM test
+//  target — every symbol here must stay free of `L.*`/`Logger`/UI dependency.
+//
+
+import Foundation
+
+// MARK: - Internal data model
+
+/// Grok Build / SuperGrok usage (app-normalized structure)
+struct GrokUsageData: Sendable {
+    /// Weekly subscription usage window (primary ring)
+    let weekly: LimitData?
+    /// Monthly included allowance window (secondary ring)
+    let monthly: LimitData?
+    /// Prepaid / on-demand credits residual info
+    let credits: GrokCreditsData?
+
+    struct LimitData: Sendable {
+        /// Used percentage 0–100
+        let percentage: Double
+        /// Reset / period end; nil if unknown
+        let resetsAt: Date?
+        /// Optional absolute used amount (monthly form)
+        let used: Double?
+        /// Optional absolute limit amount (monthly form)
+        let limit: Double?
+    }
+}
+
+/// Prepaid / on-demand credit residual for Grok
+nonisolated struct GrokCreditsData: Sendable {
+    let prepaidBalance: Double?
+    let onDemandCap: Double?
+    let onDemandUsed: Double?
+    let creditUsagePercent: Double?
+    let isUnifiedBillingUser: Bool
+
+    var enabled: Bool {
+        if let p = prepaidBalance, p > 0 { return true }
+        if let cap = onDemandCap, cap > 0 { return true }
+        if let used = onDemandUsed, used > 0 { return true }
+        if let pct = creditUsagePercent, pct > 0 { return true }
+        return isUnifiedBillingUser && (creditUsagePercent != nil)
+    }
+
+    /// Visual fill for the "extra/credits" hexagon — prefer explicit percent,
+    /// else on-demand used/cap ratio, else 0 when prepaid remains.
+    var percentage: Double? {
+        if let pct = creditUsagePercent {
+            return min(100, max(0, pct))
+        }
+        if let cap = onDemandCap, cap > 0, let used = onDemandUsed {
+            return min(100, max(0, used / cap * 100))
+        }
+        if let balance = prepaidBalance, balance > 0 {
+            return 0
+        }
+        return nil
+    }
+}
+
+// MARK: - API response models
+
+/// Credits-format response: `GET .../billing?format=credits`
+nonisolated struct GrokCreditsBillingResponse: Codable, Sendable {
+    let config: Config?
+
+    struct Config: Codable, Sendable {
+        let currentPeriod: Period?
+        let creditUsagePercent: Double?
+        let onDemandCap: ValNumber?
+        let onDemandUsed: ValNumber?
+        let productUsage: [ProductUsage]?
+        let isUnifiedBillingUser: Bool?
+        let prepaidBalance: ValNumber?
+        let billingPeriodStart: String?
+        let billingPeriodEnd: String?
+        let topUpMethod: String?
+    }
+
+    struct Period: Codable, Sendable {
+        let type: String?
+        let start: String?
+        let end: String?
+    }
+
+    struct ProductUsage: Codable, Sendable {
+        let product: String?
+        let usagePercent: Double?
+    }
+
+    struct ValNumber: Codable, Sendable {
+        let val: Double?
+
+        init(val: Double?) { self.val = val }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let d = try? container.decodeIfPresent(Double.self, forKey: .val) {
+                val = d
+            } else if let i = try? container.decodeIfPresent(Int.self, forKey: .val) {
+                val = Double(i)
+            } else if let s = try? container.decodeIfPresent(String.self, forKey: .val),
+                      let d = Double(s) {
+                val = d
+            } else {
+                val = nil
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey { case val }
+    }
+
+    /// Weekly usage percent: prefer productUsage for GrokBuild, fall back to creditUsagePercent.
+    var weeklyUsagePercent: Double? {
+        if let product = config?.productUsage?.first(where: {
+            ($0.product ?? "").localizedCaseInsensitiveContains("grok")
+        })?.usagePercent {
+            return product
+        }
+        if let first = config?.productUsage?.first?.usagePercent {
+            return first
+        }
+        return config?.creditUsagePercent
+    }
+
+    func weeklyLimitData(using parser: ISO8601DateFormatter) -> GrokUsageData.LimitData? {
+        guard let pct = weeklyUsagePercent else { return nil }
+        let end = config?.currentPeriod?.end.flatMap { parser.date(from: $0) }
+            ?? config?.billingPeriodEnd.flatMap { parser.date(from: $0) }
+        // Treat 0% with no end date as "no data yet"
+        if pct == 0 && end == nil { return nil }
+        return .init(percentage: min(100, max(0, pct)), resetsAt: end, used: nil, limit: nil)
+    }
+
+    func creditsData() -> GrokCreditsData? {
+        guard let config else { return nil }
+        let data = GrokCreditsData(
+            prepaidBalance: config.prepaidBalance?.val,
+            onDemandCap: config.onDemandCap?.val,
+            onDemandUsed: config.onDemandUsed?.val,
+            creditUsagePercent: config.creditUsagePercent,
+            isUnifiedBillingUser: config.isUnifiedBillingUser ?? false
+        )
+        return data.enabled || data.percentage != nil ? data : nil
+    }
+}
+
+/// Monthly/default response: `GET .../billing` (no format=credits)
+nonisolated struct GrokMonthlyBillingResponse: Codable, Sendable {
+    let config: Config?
+
+    struct Config: Codable, Sendable {
+        let monthlyLimit: ValNumber?
+        let used: ValNumber?
+        let onDemandCap: ValNumber?
+        let billingPeriodStart: String?
+        let billingPeriodEnd: String?
+        let history: [HistoryEntry]?
+    }
+
+    struct HistoryEntry: Codable, Sendable {
+        let billingCycle: BillingCycle?
+        let includedUsed: ValNumber?
+        let onDemandUsed: ValNumber?
+        let totalUsed: ValNumber?
+    }
+
+    struct BillingCycle: Codable, Sendable {
+        let year: Int?
+        let month: Int?
+    }
+
+    struct ValNumber: Codable, Sendable {
+        let val: Double?
+
+        init(val: Double?) { self.val = val }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let d = try? container.decodeIfPresent(Double.self, forKey: .val) {
+                val = d
+            } else if let i = try? container.decodeIfPresent(Int.self, forKey: .val) {
+                val = Double(i)
+            } else if let s = try? container.decodeIfPresent(String.self, forKey: .val),
+                      let d = Double(s) {
+                val = d
+            } else {
+                val = nil
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey { case val }
+    }
+
+    func monthlyLimitData(using parser: ISO8601DateFormatter) -> GrokUsageData.LimitData? {
+        guard let limit = config?.monthlyLimit?.val, limit > 0,
+              let used = config?.used?.val else { return nil }
+        let pct = min(100, max(0, used / limit * 100))
+        let end = config?.billingPeriodEnd.flatMap { parser.date(from: $0) }
+        return .init(percentage: pct, resetsAt: end, used: used, limit: limit)
+    }
+}
+
+// MARK: - Merge helper
+
+enum GrokUsageDataBuilder {
+    static func makeISO8601Parser() -> ISO8601DateFormatter {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }
+
+    static func makeISO8601ParserNoFraction() -> ISO8601DateFormatter {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }
+
+    static func parseDate(_ string: String?) -> Date? {
+        guard let string, !string.isEmpty else { return nil }
+        if let d = makeISO8601Parser().date(from: string) { return d }
+        return makeISO8601ParserNoFraction().date(from: string)
+    }
+
+    /// Combine credits + monthly billing payloads into one `GrokUsageData`.
+    static func combine(
+        credits: GrokCreditsBillingResponse?,
+        monthly: GrokMonthlyBillingResponse?
+    ) -> GrokUsageData {
+        let frac = makeISO8601Parser()
+        let noFrac = makeISO8601ParserNoFraction()
+
+        func weeklyFromCredits(_ c: GrokCreditsBillingResponse) -> GrokUsageData.LimitData? {
+            guard let pct = c.weeklyUsagePercent else { return nil }
+            let endStr = c.config?.currentPeriod?.end ?? c.config?.billingPeriodEnd
+            let end = endStr.flatMap { frac.date(from: $0) ?? noFrac.date(from: $0) }
+            if pct == 0 && end == nil { return nil }
+            return .init(percentage: min(100, max(0, pct)), resetsAt: end, used: nil, limit: nil)
+        }
+
+        func monthlyFrom(_ m: GrokMonthlyBillingResponse) -> GrokUsageData.LimitData? {
+            guard let limit = m.config?.monthlyLimit?.val, limit > 0,
+                  let used = m.config?.used?.val else { return nil }
+            let pct = min(100, max(0, used / limit * 100))
+            let endStr = m.config?.billingPeriodEnd
+            let end = endStr.flatMap { frac.date(from: $0) ?? noFrac.date(from: $0) }
+            return .init(percentage: pct, resetsAt: end, used: used, limit: limit)
+        }
+
+        return GrokUsageData(
+            weekly: credits.flatMap(weeklyFromCredits),
+            monthly: monthly.flatMap(monthlyFrom),
+            credits: credits?.creditsData()
+        )
+    }
+}
+
+// MARK: - Formatting bridge
+
+extension GrokUsageData.LimitData {
+    /// Convert to Claude-shaped LimitData for shared countdown formatters
+    func asUsageLimitData() -> UsageData.LimitData {
+        UsageData.LimitData(percentage: percentage, resetsAt: resetsAt)
+    }
+}

--- a/Usage4Claude/Models/ProviderType.swift
+++ b/Usage4Claude/Models/ProviderType.swift
@@ -11,11 +11,13 @@ import Foundation
 enum ProviderType: String, Codable, CaseIterable, Hashable {
     case claude
     case codex
+    case grok
 
     var displayName: String {
         switch self {
         case .claude: return "Claude"
         case .codex: return "Codex"
+        case .grok: return "Grok"
         }
     }
 }

--- a/Usage4Claude/Models/UserSettings.swift
+++ b/Usage4Claude/Models/UserSettings.swift
@@ -135,6 +135,12 @@ enum LimitType: String, CaseIterable, Codable {
     case codexSecondary = "codex_secondary"
     /// Codex Extra Usage / credits
     case codexExtraUsage = "codex_extra_usage"
+    /// Grok weekly subscription window
+    case grokWeekly = "grok_weekly"
+    /// Grok monthly included allowance
+    case grokMonthly = "grok_monthly"
+    /// Grok prepaid / on-demand credits
+    case grokCredits = "grok_credits"
 
     /// 所属 Provider
     var provider: ProviderType {
@@ -143,12 +149,16 @@ enum LimitType: String, CaseIterable, Codable {
             return .claude
         case .codexPrimary, .codexSecondary, .codexExtraUsage:
             return .codex
+        case .grokWeekly, .grokMonthly, .grokCredits:
+            return .grok
         }
     }
 
     /// 是否为圆形图标（5小时、7天和 Codex 两项）
     var isCircular: Bool {
-        return self == .fiveHour || self == .sevenDay || self == .codexPrimary || self == .codexSecondary
+        return self == .fiveHour || self == .sevenDay
+            || self == .codexPrimary || self == .codexSecondary
+            || self == .grokWeekly || self == .grokMonthly
     }
 
     /// 是否为矩形图标（Opus和Sonnet）
@@ -158,12 +168,12 @@ enum LimitType: String, CaseIterable, Codable {
 
     /// 是否为六边形图标（Extra Usage）
     var isHexagonal: Bool {
-        return self == .extraUsage || self == .codexExtraUsage
+        return self == .extraUsage || self == .codexExtraUsage || self == .grokCredits
     }
 
     /// 是否使用虚线样式（7天类型）
     var usesDashedStyle: Bool {
-        return self == .sevenDay || self == .codexSecondary
+        return self == .sevenDay || self == .codexSecondary || self == .grokMonthly
     }
 
     /// 显示名称
@@ -185,6 +195,12 @@ enum LimitType: String, CaseIterable, Codable {
             return L.LimitTypes.codexSecondary
         case .codexExtraUsage:
             return L.LimitTypes.codexExtraUsage
+        case .grokWeekly:
+            return L.LimitTypes.grokWeekly
+        case .grokMonthly:
+            return L.LimitTypes.grokMonthly
+        case .grokCredits:
+            return L.LimitTypes.grokCredits
         }
     }
 }
@@ -376,19 +392,47 @@ class UserSettings: ObservableObject {
     var codexSessionToken: String { accountStore.codexSessionToken }
     var hasValidCodexCredentials: Bool { accountStore.hasValidCodexCredentials }
 
+    // MARK: - Grok 账户支持
+
+    var grokAccounts: [Account] { accountStore.grokAccounts }
+    var currentGrokAccountId: UUID? { accountStore.currentGrokAccountId }
+    var currentGrokAccount: Account? { accountStore.currentGrokAccount }
+    var grokRefreshToken: String { accountStore.grokRefreshToken }
+    var hasValidGrokCredentials: Bool { accountStore.hasValidGrokCredentials }
+
+    /// Number of active providers with credentials (Claude / Codex / Grok)
+    var activeProviderCount: Int {
+        #if DEBUG
+        if debugModeEnabled {
+            if displayMode == .custom {
+                var count = 0
+                if customDisplayTypes.contains(where: { $0.provider == .claude }) { count += 1 }
+                if customDisplayTypes.contains(where: { $0.provider == .codex }) { count += 1 }
+                if customDisplayTypes.contains(where: { $0.provider == .grok }) { count += 1 }
+                return max(count, 1)
+            }
+            return 3
+        }
+        #endif
+        var count = 0
+        if !accounts.isEmpty { count += 1 }
+        if !codexAccounts.isEmpty { count += 1 }
+        if !grokAccounts.isEmpty { count += 1 }
+        return count
+    }
+
     /// 是否同时存在 Claude 和 Codex 账户（决定 UI 进入 multi-provider 形态）
     var isMultiProviderActive: Bool {
         #if DEBUG
         if debugModeEnabled {
             if displayMode == .custom {
-                let hasClaudeDisplayTypes = customDisplayTypes.contains { $0.provider == .claude }
-                let hasCodexDisplayTypes = customDisplayTypes.contains { $0.provider == .codex }
-                return hasClaudeDisplayTypes && hasCodexDisplayTypes
+                let providers = Set(customDisplayTypes.map(\.provider))
+                return providers.count >= 2
             }
             return true
         }
         #endif
-        return !accounts.isEmpty && !codexAccounts.isEmpty
+        return activeProviderCount >= 2
     }
 
     // MARK: - 非敏感设置（存储在UserDefaults中）
@@ -579,6 +623,22 @@ class UserSettings: ObservableObject {
     @Published var debugCodexExtraUsagePercentage: Double {
         didSet {
             defaults.set(debugCodexExtraUsagePercentage, forKey: "debugCodexExtraUsagePercentage")
+            NotificationCenter.default.post(name: .settingsChanged, object: nil)
+        }
+    }
+
+    /// Debug: Grok weekly usage percent (0-100)
+    @Published var debugGrokWeeklyPercentage: Double {
+        didSet {
+            defaults.set(debugGrokWeeklyPercentage, forKey: "debugGrokWeeklyPercentage")
+            NotificationCenter.default.post(name: .settingsChanged, object: nil)
+        }
+    }
+
+    /// Debug: Grok monthly usage percent (0-100)
+    @Published var debugGrokMonthlyPercentage: Double {
+        didSet {
+            defaults.set(debugGrokMonthlyPercentage, forKey: "debugGrokMonthlyPercentage")
             NotificationCenter.default.post(name: .settingsChanged, object: nil)
         }
     }
@@ -804,6 +864,8 @@ class UserSettings: ObservableObject {
         self.debugCodexPrimaryPercentage = defaults.object(forKey: "debugCodexPrimaryPercentage") as? Double ?? 42.0
         self.debugCodexSecondaryPercentage = defaults.object(forKey: "debugCodexSecondaryPercentage") as? Double ?? 58.0
         self.debugCodexExtraUsagePercentage = defaults.object(forKey: "debugCodexExtraUsagePercentage") as? Double ?? 35.0
+        self.debugGrokWeeklyPercentage = defaults.object(forKey: "debugGrokWeeklyPercentage") as? Double ?? 28.0
+        self.debugGrokMonthlyPercentage = defaults.object(forKey: "debugGrokMonthlyPercentage") as? Double ?? 53.0
         self.debugExtraUsageEnabled = defaults.object(forKey: "debugExtraUsageEnabled") as? Bool ?? true
         self.debugExtraUsageUsed = defaults.object(forKey: "debugExtraUsageUsed") as? Double ?? 3050.0
         self.debugExtraUsageLimit = defaults.object(forKey: "debugExtraUsageLimit") as? Int ?? 5000
@@ -846,7 +908,7 @@ class UserSettings: ObservableObject {
 
     /// 检查任一 Provider 的认证信息是否已配置
     var hasAnyValidCredentials: Bool {
-        return hasValidCredentials || hasValidCodexCredentials
+        return hasValidCredentials || hasValidCodexCredentials || hasValidGrokCredentials
     }
 
     /// 验证 Organization ID 格式
@@ -1021,6 +1083,41 @@ class UserSettings: ObservableObject {
         accountStore.silentlyUpdateCurrentCodexSessionToken(token)
     }
 
+    // MARK: - Grok Account Management
+
+    @discardableResult
+    func addGrokAccount(_ account: Account) -> Account {
+        let (stored, wasFirst) = accountStore.addGrokAccount(account)
+        if wasFirst {
+            ensureDefaultGrokDisplayTypesForCustomMode()
+        }
+        return stored
+    }
+
+    func removeGrokAccount(_ account: Account) {
+        accountStore.removeGrokAccount(account)
+    }
+
+    func switchToGrokAccount(_ account: Account) {
+        accountStore.switchToGrokAccount(account)
+    }
+
+    func updateGrokAccount(_ account: Account, alias: String?) {
+        accountStore.updateGrokAccount(account, alias: alias)
+    }
+
+    func silentlyUpdateCurrentGrokRefreshToken(_ token: String) {
+        accountStore.silentlyUpdateCurrentGrokRefreshToken(token)
+    }
+
+    private func ensureDefaultGrokDisplayTypesForCustomMode() {
+        guard displayMode == .custom else { return }
+        let grokTypes: Set<LimitType> = [.grokWeekly, .grokMonthly, .grokCredits]
+        guard customDisplayTypes.isDisjoint(with: grokTypes) else { return }
+        customDisplayTypes.formUnion(grokTypes)
+        Logger.settings.notice("Added default Grok display types for custom mode")
+    }
+
     /// 静默更新当前 Claude 账户的 session-token（不触发 accountChanged 通知）
     /// 用于 OAuth refresh_token 轮换场景——只更新持久化数据，不触发重新拉取循环
     func silentlyUpdateCurrentClaudeSessionToken(_ token: String) {
@@ -1049,10 +1146,16 @@ class UserSettings: ObservableObject {
     /// - Parameters:
     ///   - usageData: Claude 用量数据
     ///   - codexUsageData: Codex 用量数据（可选，有 Codex 账号时传入）
+    ///   - grokUsageData: Grok 用量数据（可选）
     ///   - forMenuBar: 是否用于菜单栏渲染。当 customDisplayMenuBarOnly 开启时，
     ///                 仅菜单栏走 custom 分支，Popover 自动 fallback 到 smart 分支
     /// - Returns: 要显示的限制类型数组，按显示顺序排列
-    func getActiveDisplayTypes(usageData: UsageData?, codexUsageData: CodexUsageData? = nil, forMenuBar: Bool = false) -> [LimitType] {
+    func getActiveDisplayTypes(
+        usageData: UsageData?,
+        codexUsageData: CodexUsageData? = nil,
+        grokUsageData: GrokUsageData? = nil,
+        forMenuBar: Bool = false
+    ) -> [LimitType] {
         // 当"仅应用于菜单栏"开启且当前是为 Popover 渲染时，强制走智能分支
         let effectiveMode: DisplayMode = {
             if displayMode == .custom && customDisplayMenuBarOnly && !forMenuBar {
@@ -1096,20 +1199,37 @@ class UserSettings: ObservableObject {
                 }
             }
 
+            if let grok = grokUsageData {
+                if grok.weekly != nil {
+                    types.append(.grokWeekly)
+                }
+                if grok.monthly != nil {
+                    types.append(.grokMonthly)
+                }
+                if grok.credits?.enabled == true {
+                    types.append(.grokCredits)
+                }
+            }
+
             return types
 
         case .custom:
             // 自定义模式：按用户选择排序，无论数据是否存在都显示
-            // Codex 类型仅在有 Codex 账号时纳入候选；Debug mock 模式例外
+            // Codex / Grok 类型仅在有对应账号时纳入候选；Debug mock 模式例外
             var orderedTypes: [LimitType] = [.fiveHour, .sevenDay, .extraUsage, .opusWeekly, .sonnetWeekly]
             var shouldIncludeCodexTypes = !codexAccounts.isEmpty
+            var shouldIncludeGrokTypes = !grokAccounts.isEmpty
             #if DEBUG
             if debugModeEnabled {
                 shouldIncludeCodexTypes = true
+                shouldIncludeGrokTypes = true
             }
             #endif
             if shouldIncludeCodexTypes {
                 orderedTypes.append(contentsOf: [.codexPrimary, .codexSecondary, .codexExtraUsage])
+            }
+            if shouldIncludeGrokTypes {
+                orderedTypes.append(contentsOf: [.grokWeekly, .grokMonthly, .grokCredits])
             }
             return orderedTypes.filter { customDisplayTypes.contains($0) }
         }

--- a/Usage4Claude/Resources/de.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/de.lproj/Localizable.strings
@@ -435,3 +435,19 @@
 "weblogin.claude_oauth_manual_prompt" = "Den Link aus der Adressleiste des Browsers einfügen (beginnt mit http://localhost)";
 "weblogin.claude_oauth_manual_submit" = "Mit diesem Link anmelden";
 "weblogin.claude_oauth_manual_invalid" = "Kein Autorisierungscode gefunden. Den vollständigen Link aus der Adressleiste des Browsers kopieren und erneut versuchen.";
+
+/* Grok usage monitoring */
+"usage.grok_title" = "Grok Usage";
+"grok_weekly_limit" = "Grok Weekly Limit";
+"grok_monthly_limit" = "Grok Monthly Limit";
+"grok_credits" = "Grok Credits";
+"account.grok_accounts" = "Grok Accounts";
+"account.grok_current_account" = "Current Grok Account";
+"account.import_grok_auth" = "Import Grok Auth";
+"account.import_grok_auth_help" = "Import credentials from Grok CLI ~/.grok/auth.json";
+"account.grok_device_login" = "Grok Device Login";
+"account.grok_device_login_help" = "Sign in to Grok via browser device code";
+"account.grok_device_code_hint" = "Enter this code in the browser if prompted:";
+"account.grok_open_browser" = "Open Browser";
+"account.grok_device_preparing" = "Preparing device login…";
+"account.grok_import_success" = "Grok account added successfully";

--- a/Usage4Claude/Resources/en.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/en.lproj/Localizable.strings
@@ -436,3 +436,19 @@
 "weblogin.claude_oauth_manual_prompt" = "Paste the link from your browser's address bar (starts with http://localhost)";
 "weblogin.claude_oauth_manual_submit" = "Sign in with this link";
 "weblogin.claude_oauth_manual_invalid" = "No authorization code found. Copy the full link from your browser's address bar and try again.";
+
+/* Grok usage monitoring */
+"usage.grok_title" = "Grok Usage";
+"grok_weekly_limit" = "Grok Weekly Limit";
+"grok_monthly_limit" = "Grok Monthly Limit";
+"grok_credits" = "Grok Credits";
+"account.grok_accounts" = "Grok Accounts";
+"account.grok_current_account" = "Current Grok Account";
+"account.import_grok_auth" = "Import Grok Auth";
+"account.import_grok_auth_help" = "Import credentials from Grok CLI ~/.grok/auth.json";
+"account.grok_device_login" = "Grok Device Login";
+"account.grok_device_login_help" = "Sign in to Grok via browser device code";
+"account.grok_device_code_hint" = "Enter this code in the browser if prompted:";
+"account.grok_open_browser" = "Open Browser";
+"account.grok_device_preparing" = "Preparing device login…";
+"account.grok_import_success" = "Grok account added successfully";

--- a/Usage4Claude/Resources/fr.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/fr.lproj/Localizable.strings
@@ -436,3 +436,19 @@
 "weblogin.claude_oauth_manual_prompt" = "Collez le lien depuis la barre d'adresse de votre navigateur (commence par http://localhost)";
 "weblogin.claude_oauth_manual_submit" = "Se connecter avec ce lien";
 "weblogin.claude_oauth_manual_invalid" = "Aucun code d'autorisation trouvé. Copiez le lien complet depuis la barre d'adresse et réessayez.";
+
+/* Grok usage monitoring */
+"usage.grok_title" = "Grok Usage";
+"grok_weekly_limit" = "Grok Weekly Limit";
+"grok_monthly_limit" = "Grok Monthly Limit";
+"grok_credits" = "Grok Credits";
+"account.grok_accounts" = "Grok Accounts";
+"account.grok_current_account" = "Current Grok Account";
+"account.import_grok_auth" = "Import Grok Auth";
+"account.import_grok_auth_help" = "Import credentials from Grok CLI ~/.grok/auth.json";
+"account.grok_device_login" = "Grok Device Login";
+"account.grok_device_login_help" = "Sign in to Grok via browser device code";
+"account.grok_device_code_hint" = "Enter this code in the browser if prompted:";
+"account.grok_open_browser" = "Open Browser";
+"account.grok_device_preparing" = "Preparing device login…";
+"account.grok_import_success" = "Grok account added successfully";

--- a/Usage4Claude/Resources/ja.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ja.lproj/Localizable.strings
@@ -436,3 +436,19 @@
 "weblogin.claude_oauth_manual_prompt" = "ブラウザのアドレスバーのリンクを貼り付けてください（http://localhost で始まります）";
 "weblogin.claude_oauth_manual_submit" = "このリンクでサインイン";
 "weblogin.claude_oauth_manual_invalid" = "認証コードが見つかりませんでした。ブラウザのアドレスバーの完全なリンクをコピーして、もう一度お試しください。";
+
+/* Grok usage monitoring */
+"usage.grok_title" = "Grok Usage";
+"grok_weekly_limit" = "Grok Weekly Limit";
+"grok_monthly_limit" = "Grok Monthly Limit";
+"grok_credits" = "Grok Credits";
+"account.grok_accounts" = "Grok Accounts";
+"account.grok_current_account" = "Current Grok Account";
+"account.import_grok_auth" = "Import Grok Auth";
+"account.import_grok_auth_help" = "Import credentials from Grok CLI ~/.grok/auth.json";
+"account.grok_device_login" = "Grok Device Login";
+"account.grok_device_login_help" = "Sign in to Grok via browser device code";
+"account.grok_device_code_hint" = "Enter this code in the browser if prompted:";
+"account.grok_open_browser" = "Open Browser";
+"account.grok_device_preparing" = "Preparing device login…";
+"account.grok_import_success" = "Grok account added successfully";

--- a/Usage4Claude/Resources/ko.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ko.lproj/Localizable.strings
@@ -436,3 +436,19 @@
 "weblogin.claude_oauth_manual_prompt" = "브라우저 주소창의 링크를 여기에 붙여넣으세요 (http://localhost 로 시작)";
 "weblogin.claude_oauth_manual_submit" = "이 링크로 로그인";
 "weblogin.claude_oauth_manual_invalid" = "인증 코드를 찾을 수 없습니다. 브라우저 주소창의 전체 링크를 복사한 후 다시 시도하세요.";
+
+/* Grok usage monitoring */
+"usage.grok_title" = "Grok Usage";
+"grok_weekly_limit" = "Grok Weekly Limit";
+"grok_monthly_limit" = "Grok Monthly Limit";
+"grok_credits" = "Grok Credits";
+"account.grok_accounts" = "Grok Accounts";
+"account.grok_current_account" = "Current Grok Account";
+"account.import_grok_auth" = "Import Grok Auth";
+"account.import_grok_auth_help" = "Import credentials from Grok CLI ~/.grok/auth.json";
+"account.grok_device_login" = "Grok Device Login";
+"account.grok_device_login_help" = "Sign in to Grok via browser device code";
+"account.grok_device_code_hint" = "Enter this code in the browser if prompted:";
+"account.grok_open_browser" = "Open Browser";
+"account.grok_device_preparing" = "Preparing device login…";
+"account.grok_import_success" = "Grok account added successfully";

--- a/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
@@ -436,3 +436,19 @@
 "weblogin.claude_oauth_manual_prompt" = "把浏览器地址栏里的链接粘贴到这里（以 http://localhost 开头）";
 "weblogin.claude_oauth_manual_submit" = "用此链接登录";
 "weblogin.claude_oauth_manual_invalid" = "没有从粘贴的内容中找到授权码。请复制浏览器地址栏里的完整链接后重试。";
+
+/* Grok usage monitoring */
+"usage.grok_title" = "Grok Usage";
+"grok_weekly_limit" = "Grok Weekly Limit";
+"grok_monthly_limit" = "Grok Monthly Limit";
+"grok_credits" = "Grok Credits";
+"account.grok_accounts" = "Grok Accounts";
+"account.grok_current_account" = "Current Grok Account";
+"account.import_grok_auth" = "Import Grok Auth";
+"account.import_grok_auth_help" = "Import credentials from Grok CLI ~/.grok/auth.json";
+"account.grok_device_login" = "Grok Device Login";
+"account.grok_device_login_help" = "Sign in to Grok via browser device code";
+"account.grok_device_code_hint" = "Enter this code in the browser if prompted:";
+"account.grok_open_browser" = "Open Browser";
+"account.grok_device_preparing" = "Preparing device login…";
+"account.grok_import_success" = "Grok account added successfully";

--- a/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
@@ -436,3 +436,19 @@
 "weblogin.claude_oauth_manual_prompt" = "將瀏覽器網址列的連結貼到這裡（以 http://localhost 開頭）";
 "weblogin.claude_oauth_manual_submit" = "以此連結登入";
 "weblogin.claude_oauth_manual_invalid" = "無法從貼上的內容中找到授權碼。請複製瀏覽器網址列的完整連結後重試。";
+
+/* Grok usage monitoring */
+"usage.grok_title" = "Grok Usage";
+"grok_weekly_limit" = "Grok Weekly Limit";
+"grok_monthly_limit" = "Grok Monthly Limit";
+"grok_credits" = "Grok Credits";
+"account.grok_accounts" = "Grok Accounts";
+"account.grok_current_account" = "Current Grok Account";
+"account.import_grok_auth" = "Import Grok Auth";
+"account.import_grok_auth_help" = "Import credentials from Grok CLI ~/.grok/auth.json";
+"account.grok_device_login" = "Grok Device Login";
+"account.grok_device_login_help" = "Sign in to Grok via browser device code";
+"account.grok_device_code_hint" = "Enter this code in the browser if prompted:";
+"account.grok_open_browser" = "Open Browser";
+"account.grok_device_preparing" = "Preparing device login…";
+"account.grok_import_success" = "Grok account added successfully";

--- a/Usage4Claude/Services/GrokAPIService.swift
+++ b/Usage4Claude/Services/GrokAPIService.swift
@@ -1,0 +1,318 @@
+//
+//  GrokAPIService.swift
+//  Usage4Claude
+//
+//  Grok Build usage service.
+//  Auth: OIDC refresh_token (stored in Account.sessionKey) → access_token.
+//  Usage: GET cli-chat-proxy.grok.com/v1/billing (?format=credits + monthly form).
+//
+
+import Foundation
+import OSLog
+
+/// Grok usage API service
+class GrokAPIService {
+
+    // MARK: - Properties
+
+    private let settings = UserSettings.shared
+    private let session: URLSession
+    private var activeTasks: [URLSessionDataTask] = []
+    private let tasksLock = NSLock()
+
+    /// Refresh when access token is within 20 minutes of expiry
+    private static let tokenRefreshMargin: TimeInterval = 20 * 60
+
+    private let tokenCache = OAuthTokenCache()
+
+    private func trackTask(_ task: URLSessionDataTask) {
+        tasksLock.lock()
+        activeTasks.append(task)
+        tasksLock.unlock()
+    }
+
+    func clearAccessTokenCache() {
+        Task { await tokenCache.clear() }
+    }
+
+    // MARK: - Init
+
+    init() {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 60
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        self.session = URLSession(configuration: configuration)
+    }
+
+    // MARK: - Public
+
+    /// Fetch Grok usage (refresh token → access token → billing endpoints)
+    func fetchUsage(completion: @escaping (Result<GrokUsageData, Error>) -> Void) {
+        #if DEBUG
+        if settings.debugModeEnabled {
+            let mock = createMockData()
+            DispatchQueue.main.async { completion(.success(mock)) }
+            return
+        }
+        #endif
+
+        cancelAllRequests()
+
+        guard settings.hasValidGrokCredentials else {
+            completion(.failure(UsageError.noCredentials))
+            return
+        }
+
+        let refreshToken = settings.grokRefreshToken
+
+        fetchAccessToken(refreshToken: refreshToken) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let accessToken):
+                self.fetchBilling(accessToken: accessToken) { usageResult in
+                    DispatchQueue.main.async { completion(usageResult) }
+                }
+            }
+        }
+    }
+
+    func fetchUsageResult() async -> Result<GrokUsageData, Error> {
+        await withCheckedContinuation { continuation in
+            fetchUsage { continuation.resume(returning: $0) }
+        }
+    }
+
+    /// Validate credentials by refreshing + hitting credits billing once
+    func validateAndFetchIdentity(
+        refreshToken: String,
+        completion: @escaping (Result<(email: String, teamId: String), Error>) -> Void
+    ) {
+        GrokOAuthService.refresh(refreshToken: refreshToken) { result in
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let tokens):
+                let email = tokens.email ?? "Grok"
+                let teamId = tokens.teamId ?? tokens.userId ?? UUID().uuidString
+                // Confirm billing is reachable
+                self.fetchBilling(accessToken: tokens.accessToken) { billing in
+                    switch billing {
+                    case .success:
+                        completion(.success((email: email, teamId: teamId)))
+                    case .failure(let error):
+                        // Auth worked even if billing fails; still accept the account
+                        if case UsageError.unauthorized = error {
+                            completion(.failure(error))
+                        } else {
+                            completion(.success((email: email, teamId: teamId)))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Token
+
+    private func fetchAccessToken(
+        refreshToken: String,
+        completion: @escaping (Result<String, Error>) -> Void
+    ) {
+        Task {
+            do {
+                let accessToken = try await tokenCache.accessToken(
+                    refreshToken: refreshToken,
+                    margin: Self.tokenRefreshMargin
+                ) { [weak self] credential in
+                    guard self != nil else { throw UsageError.networkError }
+                    let tokens = try await GrokOAuthService.refresh(refreshToken: credential)
+                    // Persist rotated refresh_token if present
+                    if tokens.refreshToken != credential, !tokens.refreshToken.isEmpty {
+                        await MainActor.run {
+                            UserSettings.shared.silentlyUpdateCurrentGrokRefreshToken(tokens.refreshToken)
+                        }
+                    }
+                    return tokens
+                }
+                await MainActor.run { completion(.success(accessToken)) }
+            } catch {
+                switch error {
+                case UsageError.unauthorized, UsageError.sessionExpired:
+                    break
+                default:
+                    if let fallback = await tokenCache.validCachedToken(refreshToken: refreshToken) {
+                        Logger.api.warning("Grok token refresh failed (\(error.localizedDescription)), using cached token")
+                        await MainActor.run { completion(.success(fallback)) }
+                        return
+                    }
+                }
+                await MainActor.run { completion(.failure(error)) }
+            }
+        }
+    }
+
+    // MARK: - Billing
+
+    private func fetchBilling(
+        accessToken: String,
+        completion: @escaping (Result<GrokUsageData, Error>) -> Void
+    ) {
+        let group = DispatchGroup()
+        var creditsResponse: GrokCreditsBillingResponse?
+        var monthlyResponse: GrokMonthlyBillingResponse?
+        var firstError: Error?
+        let lock = NSLock()
+
+        group.enter()
+        fetchJSON(
+            url: GrokOAuthConfig.creditsBillingURL,
+            accessToken: accessToken
+        ) { (result: Result<GrokCreditsBillingResponse, Error>) in
+            lock.lock()
+            switch result {
+            case .success(let value): creditsResponse = value
+            case .failure(let error):
+                if firstError == nil { firstError = error }
+            }
+            lock.unlock()
+            group.leave()
+        }
+
+        group.enter()
+        fetchJSON(
+            url: GrokOAuthConfig.monthlyBillingURL,
+            accessToken: accessToken
+        ) { (result: Result<GrokMonthlyBillingResponse, Error>) in
+            lock.lock()
+            switch result {
+            case .success(let value): monthlyResponse = value
+            case .failure(let error):
+                // Monthly is supplemental; only record error if credits also failed
+                if firstError == nil { firstError = error }
+            }
+            lock.unlock()
+            group.leave()
+        }
+
+        group.notify(queue: .main) {
+            if creditsResponse == nil && monthlyResponse == nil {
+                completion(.failure(firstError ?? UsageError.noData))
+                return
+            }
+            // If credits failed with unauthorized, surface that
+            if creditsResponse == nil, let err = firstError as? UsageError {
+                switch err {
+                case .unauthorized, .sessionExpired:
+                    completion(.failure(err))
+                    return
+                default:
+                    break
+                }
+            }
+            let data = GrokUsageDataBuilder.combine(credits: creditsResponse, monthly: monthlyResponse)
+            if data.weekly == nil && data.monthly == nil && data.credits == nil {
+                completion(.failure(UsageError.noData))
+                return
+            }
+            completion(.success(data))
+        }
+    }
+
+    private func fetchJSON<T: Decodable>(
+        url: URL,
+        accessToken: String,
+        completion: @escaping (Result<T, Error>) -> Void
+    ) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Usage4Claude/Grok", forHTTPHeaderField: "User-Agent")
+
+        let task = session.dataTask(with: request) { [weak self] data, response, error in
+            if let error {
+                Logger.api.debug("Grok billing error: \(error.localizedDescription)")
+                completion(.failure(UsageError.networkError))
+                return
+            }
+            guard let data else {
+                completion(.failure(UsageError.noData))
+                return
+            }
+            if let http = response as? HTTPURLResponse {
+                Logger.api.debug("Grok billing HTTP \(http.statusCode) for \(url.lastPathComponent)")
+                switch http.statusCode {
+                case 200...299:
+                    break
+                case 401:
+                    Task { await self?.tokenCache.clear() }
+                    completion(.failure(UsageError.unauthorized))
+                    return
+                case 403:
+                    completion(.failure(UsageError.cloudflareBlocked))
+                    return
+                case 429:
+                    completion(.failure(UsageError.rateLimited))
+                    return
+                default:
+                    completion(.failure(UsageError.httpError(statusCode: http.statusCode)))
+                    return
+                }
+            }
+            do {
+                let decoded = try JSONDecoder().decode(T.self, from: data)
+                completion(.success(decoded))
+            } catch {
+                Logger.api.debug("Grok billing decode error: \(error.localizedDescription)")
+                completion(.failure(UsageError.decodingError))
+            }
+        }
+        trackTask(task)
+        task.resume()
+    }
+
+    // MARK: - Debug mock
+
+    #if DEBUG
+    private func createMockData() -> GrokUsageData {
+        let weeklyPct = Double(settings.debugGrokWeeklyPercentage)
+        let monthlyPct = Double(settings.debugGrokMonthlyPercentage)
+        let weeklyReset = Date().addingTimeInterval(3600 * 24 * 3.5)
+        let monthlyReset = Date().addingTimeInterval(3600 * 24 * 12)
+        return GrokUsageData(
+            weekly: .init(percentage: weeklyPct, resetsAt: weeklyReset, used: nil, limit: nil),
+            monthly: .init(
+                percentage: monthlyPct,
+                resetsAt: monthlyReset,
+                used: monthlyPct * 1500,
+                limit: 150_000
+            ),
+            credits: GrokCreditsData(
+                prepaidBalance: 0,
+                onDemandCap: 0,
+                onDemandUsed: 0,
+                creditUsagePercent: weeklyPct,
+                isUnifiedBillingUser: true
+            )
+        )
+    }
+    #endif
+}
+
+// MARK: - UsageProvider
+
+extension GrokAPIService: UsageProvider {
+    var providerType: ProviderType { .grok }
+
+    func cancelAllRequests() {
+        tasksLock.lock()
+        let tasks = activeTasks
+        activeTasks.removeAll()
+        tasksLock.unlock()
+        tasks.forEach { $0.cancel() }
+        Logger.api.debug("Grok: cancelled in-flight network requests")
+    }
+}

--- a/Usage4Claude/Services/GrokOAuth/GrokOAuthConfig.swift
+++ b/Usage4Claude/Services/GrokOAuth/GrokOAuthConfig.swift
@@ -1,0 +1,49 @@
+//
+//  GrokOAuthConfig.swift
+//  Usage4Claude
+//
+//  OIDC config for Grok Build / xAI auth.
+//  Reuses the official Grok CLI public client (PKCE / device-code, no secret).
+//  Constants observed from Grok CLI auth (`auth.x.ai` OIDC + `~/.grok/auth.json`).
+//
+
+import Foundation
+
+enum GrokOAuthConfig {
+    /// OIDC issuer
+    static let issuer = "https://auth.x.ai"
+    /// Authorization endpoint
+    static let authorizeURL = "\(issuer)/oauth2/authorize"
+    /// Token / refresh endpoint
+    static let tokenURL = "\(issuer)/oauth2/token"
+    /// Device authorization endpoint
+    static let deviceCodeURL = "\(issuer)/oauth2/device/code"
+    /// Userinfo endpoint
+    static let userinfoURL = "\(issuer)/oauth2/userinfo"
+
+    /// Grok CLI public OAuth client id (no client secret; supports device code + PKCE)
+    static let clientID = "b1a00492-073a-47ea-816f-4c329264a828"
+
+    /// Scopes required for billing/usage + silent refresh
+    static let scope = "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write"
+
+    /// Grok Build billing/usage API base (includes `/v1`)
+    static let billingBaseURL = "https://cli-chat-proxy.grok.com/v1"
+
+    /// Credits-format weekly quota
+    static var creditsBillingURL: URL {
+        URL(string: "\(billingBaseURL)/billing?format=credits")!
+    }
+
+    /// Monthly included allowance form
+    static var monthlyBillingURL: URL {
+        URL(string: "\(billingBaseURL)/billing")!
+    }
+
+    /// Default path for Grok CLI credentials (import helper)
+    static var defaultAuthJSONPath: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".grok")
+            .appendingPathComponent("auth.json")
+    }
+}

--- a/Usage4Claude/Services/GrokOAuth/GrokOAuthService.swift
+++ b/Usage4Claude/Services/GrokOAuth/GrokOAuthService.swift
@@ -1,0 +1,333 @@
+//
+//  GrokOAuthService.swift
+//  Usage4Claude
+//
+//  Grok OIDC helpers: refresh_token → access_token, device-code login,
+//  and import of credentials from Grok CLI's ~/.grok/auth.json.
+//
+
+import Foundation
+import OSLog
+
+struct GrokOAuthTokens: Sendable {
+    let accessToken: String
+    let refreshToken: String?
+    let expiresAt: Date
+    let email: String?
+    let teamId: String?
+    let userId: String?
+}
+
+enum GrokOAuthService {
+
+    // MARK: - Refresh
+
+    /// Exchange a refresh_token for a new access_token (and possibly rotated refresh_token).
+    static func refresh(
+        refreshToken: String,
+        completion: @escaping (Result<GrokOAuthTokens, Error>) -> Void
+    ) {
+        guard let url = URL(string: GrokOAuthConfig.tokenURL) else {
+            completion(.failure(UsageError.invalidURL))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let body = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": GrokOAuthConfig.clientID
+        ]
+        request.httpBody = formURLEncoded(body).data(using: .utf8)
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error {
+                Logger.api.debug("Grok OAuth refresh network error: \(error.localizedDescription)")
+                DispatchQueue.main.async { completion(.failure(UsageError.networkError)) }
+                return
+            }
+            guard let data else {
+                DispatchQueue.main.async { completion(.failure(UsageError.noData)) }
+                return
+            }
+            if let http = response as? HTTPURLResponse {
+                Logger.api.debug("Grok OAuth refresh HTTP \(http.statusCode)")
+                if http.statusCode == 401 || http.statusCode == 400 {
+                    DispatchQueue.main.async { completion(.failure(UsageError.unauthorized)) }
+                    return
+                }
+                guard (200...299).contains(http.statusCode) else {
+                    DispatchQueue.main.async { completion(.failure(UsageError.httpError(statusCode: http.statusCode))) }
+                    return
+                }
+            }
+            do {
+                let tokens = try decodeTokenResponse(data, fallbackRefresh: refreshToken)
+                DispatchQueue.main.async { completion(.success(tokens)) }
+            } catch {
+                Logger.api.debug("Grok OAuth refresh decode error: \(error.localizedDescription)")
+                DispatchQueue.main.async { completion(.failure(UsageError.decodingError)) }
+            }
+        }.resume()
+    }
+
+    /// Async wrapper used by OAuthTokenCache
+    static func refresh(refreshToken: String) async throws -> OAuthTokenCache.Tokens {
+        try await withCheckedThrowingContinuation { continuation in
+            refresh(refreshToken: refreshToken) { result in
+                switch result {
+                case .success(let t):
+                    continuation.resume(returning: OAuthTokenCache.Tokens(
+                        accessToken: t.accessToken,
+                        refreshToken: t.refreshToken ?? refreshToken,
+                        expiresAt: t.expiresAt
+                    ))
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    // MARK: - Device code flow
+
+    struct DeviceCodeResponse: Sendable {
+        let deviceCode: String
+        let userCode: String
+        let verificationURI: URL
+        let verificationURIComplete: URL?
+        let expiresIn: Int
+        let interval: Int
+    }
+
+    static func requestDeviceCode(
+        completion: @escaping (Result<DeviceCodeResponse, Error>) -> Void
+    ) {
+        guard let url = URL(string: GrokOAuthConfig.deviceCodeURL) else {
+            completion(.failure(UsageError.invalidURL))
+            return
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let body = [
+            "client_id": GrokOAuthConfig.clientID,
+            "scope": GrokOAuthConfig.scope
+        ]
+        request.httpBody = formURLEncoded(body).data(using: .utf8)
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error {
+                Logger.api.debug("Grok device code error: \(error.localizedDescription)")
+                DispatchQueue.main.async { completion(.failure(UsageError.networkError)) }
+                return
+            }
+            guard let data else {
+                DispatchQueue.main.async { completion(.failure(UsageError.noData)) }
+                return
+            }
+            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                DispatchQueue.main.async { completion(.failure(UsageError.httpError(statusCode: http.statusCode))) }
+                return
+            }
+            do {
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+                guard let deviceCode = json["device_code"] as? String,
+                      let userCode = json["user_code"] as? String,
+                      let uriString = json["verification_uri"] as? String,
+                      let uri = URL(string: uriString) else {
+                    DispatchQueue.main.async { completion(.failure(UsageError.decodingError)) }
+                    return
+                }
+                let complete = (json["verification_uri_complete"] as? String).flatMap(URL.init(string:))
+                let expiresIn = (json["expires_in"] as? Int) ?? 600
+                let interval = (json["interval"] as? Int) ?? 5
+                let response = DeviceCodeResponse(
+                    deviceCode: deviceCode,
+                    userCode: userCode,
+                    verificationURI: uri,
+                    verificationURIComplete: complete,
+                    expiresIn: expiresIn,
+                    interval: interval
+                )
+                DispatchQueue.main.async { completion(.success(response)) }
+            } catch {
+                DispatchQueue.main.async { completion(.failure(UsageError.decodingError)) }
+            }
+        }.resume()
+    }
+
+    /// Poll the token endpoint until authorized, expired, or cancelled.
+    static func pollDeviceToken(
+        deviceCode: String,
+        interval: Int,
+        expiresIn: Int,
+        shouldCancel: @escaping () -> Bool = { false },
+        completion: @escaping (Result<GrokOAuthTokens, Error>) -> Void
+    ) {
+        let deadline = Date().addingTimeInterval(TimeInterval(expiresIn))
+        let pollInterval = max(interval, 3)
+
+        func pollOnce() {
+            if shouldCancel() {
+                completion(.failure(UsageError.sessionExpired))
+                return
+            }
+            if Date() > deadline {
+                completion(.failure(UsageError.sessionExpired))
+                return
+            }
+
+            guard let url = URL(string: GrokOAuthConfig.tokenURL) else {
+                completion(.failure(UsageError.invalidURL))
+                return
+            }
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            let body = [
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": deviceCode,
+                "client_id": GrokOAuthConfig.clientID
+            ]
+            request.httpBody = formURLEncoded(body).data(using: .utf8)
+
+            URLSession.shared.dataTask(with: request) { data, response, error in
+                if shouldCancel() {
+                    DispatchQueue.main.async { completion(.failure(UsageError.sessionExpired)) }
+                    return
+                }
+                if error != nil {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + Double(pollInterval)) { pollOnce() }
+                    return
+                }
+                guard let data else {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + Double(pollInterval)) { pollOnce() }
+                    return
+                }
+
+                // Pending / slow-down responses come back as JSON error objects
+                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let err = json["error"] as? String {
+                    switch err {
+                    case "authorization_pending", "slow_down":
+                        let delay = err == "slow_down" ? pollInterval + 5 : pollInterval
+                        DispatchQueue.main.asyncAfter(deadline: .now() + Double(delay)) { pollOnce() }
+                        return
+                    case "expired_token", "access_denied":
+                        DispatchQueue.main.async { completion(.failure(UsageError.sessionExpired)) }
+                        return
+                    default:
+                        DispatchQueue.main.async { completion(.failure(UsageError.unauthorized)) }
+                        return
+                    }
+                }
+
+                if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                    // Retry on transient server errors
+                    if (500...599).contains(http.statusCode) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + Double(pollInterval)) { pollOnce() }
+                        return
+                    }
+                    DispatchQueue.main.async { completion(.failure(UsageError.httpError(statusCode: http.statusCode))) }
+                    return
+                }
+
+                do {
+                    let tokens = try decodeTokenResponse(data, fallbackRefresh: nil)
+                    DispatchQueue.main.async { completion(.success(tokens)) }
+                } catch {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + Double(pollInterval)) { pollOnce() }
+                }
+            }.resume()
+        }
+
+        pollOnce()
+    }
+
+    // MARK: - Import ~/.grok/auth.json
+
+    /// Parse Grok CLI auth.json and return the first usable credential set.
+    static func importFromAuthJSON(at url: URL) throws -> GrokOAuthTokens {
+        let data = try Data(contentsOf: url)
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw UsageError.decodingError
+        }
+
+        // Shape: { "https://auth.x.ai::<client_id>": { key, refresh_token, email, team_id, ... } }
+        for (_, value) in root {
+            guard let entry = value as? [String: Any] else { continue }
+            let access = (entry["key"] as? String) ?? (entry["access_token"] as? String)
+            let refresh = entry["refresh_token"] as? String
+            guard let refresh, !refresh.isEmpty else { continue }
+
+            let expiresAt: Date = {
+                if let s = entry["expires_at"] as? String {
+                    let f1 = ISO8601DateFormatter()
+                    f1.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                    if let d = f1.date(from: s) { return d }
+                    let f2 = ISO8601DateFormatter()
+                    f2.formatOptions = [.withInternetDateTime]
+                    if let d = f2.date(from: s) { return d }
+                }
+                // Default: treat existing access token as short-lived; force refresh soon
+                return Date().addingTimeInterval(5 * 60)
+            }()
+
+            return GrokOAuthTokens(
+                accessToken: access ?? "",
+                refreshToken: refresh,
+                expiresAt: expiresAt,
+                email: entry["email"] as? String,
+                teamId: entry["team_id"] as? String,
+                userId: entry["user_id"] as? String
+            )
+        }
+        throw UsageError.noCredentials
+    }
+
+    // MARK: - Helpers
+
+    private static func formURLEncoded(_ params: [String: String]) -> String {
+        params
+            .map { key, value in
+                let k = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
+                let v = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+                return "\(k)=\(v)"
+            }
+            .joined(separator: "&")
+    }
+
+    private static func decodeTokenResponse(
+        _ data: Data,
+        fallbackRefresh: String?
+    ) throws -> GrokOAuthTokens {
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+        guard let access = json["access_token"] as? String, !access.isEmpty else {
+            throw UsageError.decodingError
+        }
+        let refresh = (json["refresh_token"] as? String) ?? fallbackRefresh
+        let expiresIn = (json["expires_in"] as? Int) ?? 3600
+        let expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+
+        // Optional identity fields (present on some login responses / userinfo)
+        let email = json["email"] as? String
+        let teamId = (json["team_id"] as? String) ?? (json["teamId"] as? String)
+        let userId = (json["user_id"] as? String) ?? (json["sub"] as? String)
+
+        return GrokOAuthTokens(
+            accessToken: access,
+            refreshToken: refresh,
+            expiresAt: expiresAt,
+            email: email,
+            teamId: teamId,
+            userId: userId
+        )
+    }
+}

--- a/Usage4Claude/Services/KeychainManager.swift
+++ b/Usage4Claude/Services/KeychainManager.swift
@@ -202,6 +202,22 @@ class KeychainManager {
         storage.delete(key: "accounts_codex")
     }
 
+    // MARK: - Grok 账户列表存储
+
+    @discardableResult
+    func saveGrokAccounts(_ accounts: [Account]) -> Bool {
+        saveAccountsList(accounts, key: "accounts_grok")
+    }
+
+    func loadGrokAccounts() -> [Account]? {
+        loadAccountsList(key: "accounts_grok")
+    }
+
+    @discardableResult
+    func deleteGrokAccounts() -> Bool {
+        storage.delete(key: "accounts_grok")
+    }
+
     // MARK: - 账户列表的 JSON 编解码封装
 
     @discardableResult

--- a/Usage4Claude/Services/NotificationManager.swift
+++ b/Usage4Claude/Services/NotificationManager.swift
@@ -133,6 +133,31 @@ final class NotificationManager: NSObject {
         )
     }
 
+    /// Check Grok usage thresholds and fire notifications when needed
+    func checkAndNotify(grokUsageData: GrokUsageData, previousData: GrokUsageData?) {
+        checkLimit(
+            type: .grokWeekly,
+            current: grokUsageData.weekly?.percentage,
+            previous: previousData?.weekly?.percentage,
+            currentResetsAt: grokUsageData.weekly?.resetsAt,
+            previousResetsAt: previousData?.weekly?.resetsAt
+        )
+        checkLimit(
+            type: .grokMonthly,
+            current: grokUsageData.monthly?.percentage,
+            previous: previousData?.monthly?.percentage,
+            currentResetsAt: grokUsageData.monthly?.resetsAt,
+            previousResetsAt: previousData?.monthly?.resetsAt
+        )
+        checkLimit(
+            type: .grokCredits,
+            current: grokUsageData.credits?.percentage,
+            previous: previousData?.credits?.percentage,
+            currentResetsAt: nil,
+            previousResetsAt: nil
+        )
+    }
+
     // MARK: - Private Methods
 
     /// 检查单个限制类型的用量变化
@@ -147,7 +172,7 @@ final class NotificationManager: NSObject {
     ) {
         let warningKey = notificationKey(for: type)
         // 7天限制额外检查 75% 阈值，其余类型不做早期预警
-        let earlyWarningKey = (type == .sevenDay || type == .codexSecondary)
+        let earlyWarningKey = (type == .sevenDay || type == .codexSecondary || type == .grokMonthly)
             ? notificationKey(for: type, suffix: "75")
             : nil
 
@@ -183,6 +208,8 @@ final class NotificationManager: NSObject {
             accountId = UserSettings.shared.currentAccountId
         case .codex:
             accountId = UserSettings.shared.currentCodexAccountId
+        case .grok:
+            accountId = UserSettings.shared.currentGrokAccountId
         }
         return Self.makeNotificationKey(
             provider: type.provider,

--- a/Usage4Claude/Views/Components/GrokColumnView.swift
+++ b/Usage4Claude/Views/Components/GrokColumnView.swift
@@ -1,0 +1,240 @@
+//
+//  GrokColumnView.swift
+//  Usage4Claude
+//
+//  Grok usage column (weekly + monthly rings, credits row).
+//
+
+import SwiftUI
+
+/// Grok usage column view
+struct GrokColumnView: View {
+    let grokUsageData: GrokUsageData
+    @Binding var showRemainingMode: Bool
+    let refreshState: RefreshState
+    @Binding var animationType: UsageDetailView.LoadingAnimationType
+    @Binding var rotationAngle: Double
+    let remainingModeAnimationTrigger: Int
+    var onRefresh: (() -> Void)?
+    var onAnimationHint: ((String) -> Void)?
+    var onToggleRemainingMode: (() -> Void)?
+
+    private var activeGrokTypes: [LimitType] {
+        UserSettings.shared.getActiveDisplayTypes(usageData: nil, grokUsageData: grokUsageData)
+            .filter { $0.provider == .grok }
+    }
+
+    private var primaryRingType: LimitType? {
+        if activeGrokTypes.contains(.grokWeekly) { return .grokWeekly }
+        if activeGrokTypes.contains(.grokMonthly) { return .grokMonthly }
+        return nil
+    }
+
+    private var primaryRingData: GrokUsageData.LimitData? {
+        let placeholder = GrokUsageData.LimitData(percentage: 0, resetsAt: nil, used: nil, limit: nil)
+        let showPlaceholder = UserSettings.shared.shouldShowCustomPlaceholderInPopover
+
+        switch primaryRingType {
+        case .grokWeekly:
+            return grokUsageData.weekly ?? (showPlaceholder ? placeholder : nil)
+        case .grokMonthly:
+            return grokUsageData.monthly ?? (showPlaceholder ? placeholder : nil)
+        default:
+            return nil
+        }
+    }
+
+    private var secondaryData: GrokUsageData.LimitData? { grokUsageData.monthly }
+
+    private var showSecondaryRing: Bool {
+        primaryRingType == .grokWeekly && activeGrokTypes.contains(.grokMonthly) && secondaryData != nil
+    }
+
+    private var isGrokRefreshing: Bool {
+        refreshState.isRefreshingProvider(.grok)
+    }
+
+    var body: some View {
+        VStack(spacing: 15) {
+            ZStack {
+                if let primary = primaryRingData {
+                    let primaryColor = primaryRingColor(for: primary.percentage)
+                    let primaryRange = UsageRingDisplay.displayedTrimRange(
+                        usedPercentage: primary.percentage,
+                        showRemainingMode: showRemainingMode
+                    )
+
+                    Circle()
+                        .stroke(Color.gray.opacity(0.2), lineWidth: 10)
+                        .frame(width: 100, height: 100)
+
+                    if isGrokRefreshing {
+                        grokLoadingAnimation()
+                    } else {
+                        Circle()
+                            .trim(from: primaryRange.from, to: primaryRange.to)
+                            .stroke(
+                                primaryColor,
+                                style: StrokeStyle(lineWidth: 10, lineCap: .round)
+                            )
+                            .frame(width: 100, height: 100)
+                            .rotationEffect(.degrees(-90))
+                            .animation(
+                                .spring(response: 0.42, dampingFraction: 0.78, blendDuration: 0.05),
+                                value: primaryRange
+                            )
+                    }
+
+                    if showSecondaryRing, let secondary = secondaryData {
+                        let secondaryRange = UsageRingDisplay.displayedTrimRange(
+                            usedPercentage: secondary.percentage,
+                            showRemainingMode: showRemainingMode
+                        )
+
+                        Circle()
+                            .stroke(Color.gray.opacity(0.15), lineWidth: 3)
+                            .frame(width: 114, height: 114)
+
+                        if isGrokRefreshing {
+                            grokOuterLoadingAnimation()
+                        } else {
+                            Circle()
+                                .trim(from: secondaryRange.from, to: secondaryRange.to)
+                                .stroke(
+                                    UsageColorScheme.grokMonthlyColorSwiftUI(secondary.percentage),
+                                    style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                                )
+                                .frame(width: 114, height: 114)
+                                .rotationEffect(.degrees(-90))
+                                .animation(
+                                    .spring(response: 0.42, dampingFraction: 0.78, blendDuration: 0.05),
+                                    value: secondaryRange
+                                )
+                        }
+                    }
+
+                    if !isGrokRefreshing {
+                        DetailUsageRingSweep(
+                            trigger: remainingModeAnimationTrigger,
+                            diameter: 122,
+                            lineWidth: 3,
+                            color: primaryColor
+                        )
+                    }
+
+                    DetailUsageRingCenterText(
+                        usedPercentage: primary.percentage,
+                        showRemainingMode: showRemainingMode
+                    )
+                }
+            }
+            .frame(height: 114)
+            .contentShape(Circle())
+            .onTapGesture {
+                if refreshState.canRefresh && !refreshState.isRefreshing {
+                    onRefresh?()
+                }
+            }
+            .onLongPressGesture(minimumDuration: 3.0) {
+                let allTypes = UsageDetailView.LoadingAnimationType.allCases
+                let currentIndex = allTypes.firstIndex(of: animationType) ?? 0
+                animationType = allTypes[(currentIndex + 1) % allTypes.count]
+                onAnimationHint?(animationType.name)
+            }
+
+            VStack(spacing: 5) {
+                ForEach(activeGrokTypes, id: \.self) { type in
+                    UnifiedLimitRow(
+                        type: type,
+                        grokData: grokUsageData,
+                        showRemainingMode: showRemainingMode
+                    )
+                }
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                onToggleRemainingMode?()
+            }
+            .padding(.horizontal, 14)
+        }
+    }
+
+    private func primaryRingColor(for percentage: Double) -> Color {
+        if primaryRingType == .grokMonthly {
+            return UsageColorScheme.grokMonthlyColorSwiftUI(percentage)
+        }
+        return UsageColorScheme.grokWeeklyColorSwiftUI(percentage)
+    }
+
+    private let grokPrimary = Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0)
+    private let grokPrimaryDark = Color(red: 71/255.0, green: 85/255.0, blue: 105/255.0)
+    private let grokSecondary = Color(red: 244/255.0, green: 114/255.0, blue: 182/255.0)
+    private let grokSecondaryDark = Color(red: 219/255.0, green: 39/255.0, blue: 119/255.0)
+
+    @ViewBuilder
+    private func grokLoadingAnimation() -> some View {
+        switch animationType {
+        case .rainbow:
+            Circle()
+                .trim(from: 0, to: 0.7)
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [grokPrimary, grokPrimaryDark, .gray, grokPrimary]),
+                        center: .center
+                    ),
+                    style: StrokeStyle(lineWidth: 10, lineCap: .round)
+                )
+                .frame(width: 100, height: 100)
+                .rotationEffect(.degrees(rotationAngle))
+        case .dashed:
+            Circle()
+                .trim(from: 0, to: 1)
+                .stroke(grokPrimary, style: StrokeStyle(lineWidth: 10, lineCap: .round, dash: [10, 8]))
+                .frame(width: 100, height: 100)
+                .rotationEffect(.degrees(rotationAngle))
+        case .pulse:
+            ZStack {
+                Circle()
+                    .trim(from: 0, to: 0.6)
+                    .stroke(grokPrimary.opacity(0.8), style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                    .frame(width: 90, height: 90)
+                    .rotationEffect(.degrees(rotationAngle))
+                Circle()
+                    .trim(from: 0, to: 0.4)
+                    .stroke(grokPrimary.opacity(0.4), style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                    .frame(width: 100, height: 100)
+                    .rotationEffect(.degrees(-rotationAngle * 0.7))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func grokOuterLoadingAnimation() -> some View {
+        switch animationType {
+        case .rainbow:
+            Circle()
+                .trim(from: 0, to: 0.7)
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [grokSecondary, grokSecondaryDark, .pink, grokSecondary]),
+                        center: .center
+                    ),
+                    style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                )
+                .frame(width: 114, height: 114)
+                .rotationEffect(.degrees(-rotationAngle))
+        case .dashed:
+            Circle()
+                .trim(from: 0, to: 1)
+                .stroke(grokSecondaryDark, style: StrokeStyle(lineWidth: 3, lineCap: .round, dash: [8, 6]))
+                .frame(width: 114, height: 114)
+                .rotationEffect(.degrees(-rotationAngle))
+        case .pulse:
+            Circle()
+                .trim(from: 0, to: 0.4)
+                .stroke(grokSecondaryDark.opacity(0.6), style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                .frame(width: 114, height: 114)
+                .rotationEffect(.degrees(-rotationAngle * 0.7))
+        }
+    }
+}

--- a/Usage4Claude/Views/Components/UsageRowComponents.swift
+++ b/Usage4Claude/Views/Components/UsageRowComponents.swift
@@ -196,11 +196,12 @@ struct ProviderDivider: View {
 
 // MARK: - Unified Limit Row Component
 
-/// 统一的限制行组件（支持所有 Claude 和 Codex 限制类型）
+/// 统一的限制行组件（支持 Claude / Codex / Grok 限制类型）
 struct UnifiedLimitRow: View {
     let type: LimitType
     var data: UsageData? = nil
     var codexData: CodexUsageData? = nil
+    var grokData: GrokUsageData? = nil
     let showRemainingMode: Bool
     /// 溢出模型行覆盖：提供时，行的百分比/标签/重置时间直接取自这个模型条目，
     /// `type` 仅用于决定外观（圆角方/斜切方形状与配色的槽位）。用于 popover 展示
@@ -254,14 +255,18 @@ struct UnifiedLimitRow: View {
             return L.DetailRow.fiveHour
         case .sevenDay, .codexSecondary:
             return L.DetailRow.sevenDay
+        case .grokWeekly:
+            return L.LimitTypes.grokWeekly
+        case .grokMonthly:
+            return L.LimitTypes.grokMonthly
         case .opusWeekly:
             // Claude 5 时代：此槽位可能承载来自 limits 数组的具体模型每周限制（如 Fable）。
             // 有真实模型名则优先展示，否则回退到默认的 “Opus Weekly” 文案。
             return data?.opusModelName ?? L.DetailRow.opusWeekly
         case .sonnetWeekly:
             return data?.sonnetModelName ?? L.DetailRow.sonnetWeekly
-        case .extraUsage, .codexExtraUsage:
-            return L.DetailRow.extraUsage
+        case .extraUsage, .codexExtraUsage, .grokCredits:
+            return type == .grokCredits ? L.LimitTypes.grokCredits : L.DetailRow.extraUsage
         }
     }
 
@@ -283,6 +288,12 @@ struct UnifiedLimitRow: View {
             return Color(red: 96/255.0, green: 165/255.0, blue: 250/255.0)   // #60A5FA
         case .codexExtraUsage:
             return Color(red: 245/255.0, green: 158/255.0, blue: 11/255.0)    // #F59E0B
+        case .grokWeekly:
+            return Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0)  // #64748B
+        case .grokMonthly:
+            return Color(red: 244/255.0, green: 114/255.0, blue: 182/255.0)  // #F472B6
+        case .grokCredits:
+            return Color(red: 250/255.0, green: 204/255.0, blue: 21/255.0)   // #FACC15
         }
     }
 
@@ -299,6 +310,9 @@ struct UnifiedLimitRow: View {
         case .codexPrimary:   return codexData?.primary?.percentage
         case .codexSecondary: return codexData?.secondary?.percentage
         case .codexExtraUsage: return codexData?.extraUsage?.percentage
+        case .grokWeekly:     return grokData?.weekly?.percentage
+        case .grokMonthly:    return grokData?.monthly?.percentage
+        case .grokCredits:    return grokData?.credits?.percentage
         }
     }
 
@@ -340,6 +354,23 @@ struct UnifiedLimitRow: View {
         case .codexExtraUsage:
             guard let extra = codexData?.extraUsage else { return "-" }
             return showRemainingMode ? extra.formattedDetailRemainingAmount : extra.formattedDetailCompactAmount
+
+        case .grokWeekly:
+            guard let limitData = grokData?.weekly?.asUsageLimitData() else { return "-" }
+            return showRemainingMode ? limitData.formattedCompactRemaining : detailCompactResetTime(limitData)
+
+        case .grokMonthly:
+            guard let limitData = grokData?.monthly?.asUsageLimitData() else { return "-" }
+            return showRemainingMode ? limitData.formattedCompactRemainingWithMinutes : limitData.formattedCompactResetDateWithMinutes
+
+        case .grokCredits:
+            if let pct = grokData?.credits?.percentage {
+                return String(format: "%.0f%%", pct)
+            }
+            if let balance = grokData?.credits?.prepaidBalance {
+                return String(format: "$%.2f", balance)
+            }
+            return "-"
         }
     }
 

--- a/Usage4Claude/Views/DiagnosticsView.swift
+++ b/Usage4Claude/Views/DiagnosticsView.swift
@@ -104,6 +104,7 @@ private struct ProviderResultCard: View {
         switch result.providerType {
         case .claude: return "c.circle.fill"
         case .codex: return "sparkle"
+        case .grok: return "sparkles"
         }
     }
 

--- a/Usage4Claude/Views/Settings/Tabs/AuthSettingsView+AccountDetail.swift
+++ b/Usage4Claude/Views/Settings/Tabs/AuthSettingsView+AccountDetail.swift
@@ -8,6 +8,7 @@
 //  当前 Claude / Codex 账户详情卡片，从 AuthSettingsView.swift 拆出
 
 import SwiftUI
+import AppKit
 
 extension AuthSettingsView {
 
@@ -220,6 +221,209 @@ extension AuthSettingsView {
                     .foregroundColor(.red)
                 }
                 .buttonStyle(.plain)
+            }
+        }
+    }
+
+    func currentGrokAccountDetailView(account: Account) -> some View {
+        SettingCard(
+            icon: "sparkles",
+            iconColor: Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0),
+            title: L.Account.grokCurrentAccount,
+            hint: ""
+        ) {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "tag.fill")
+                            .foregroundColor(.orange)
+                            .font(.subheadline)
+                        Text(L.Account.alias)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                    }
+
+                    HStack {
+                        TextField(account.organizationName, text: Binding(
+                            get: { account.alias ?? "" },
+                            set: { newValue in
+                                settings.updateGrokAccount(account, alias: newValue.isEmpty ? nil : newValue)
+                            }
+                        ))
+                        .textFieldStyle(.roundedBorder)
+
+                        if account.alias != nil && !account.alias!.isEmpty {
+                            Button(action: {
+                                settings.updateGrokAccount(account, alias: nil)
+                            }) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .help(L.Account.clearAlias)
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "key.fill")
+                            .foregroundColor(.red)
+                            .font(.subheadline)
+                        Text(L.SettingsAuth.sessionKeyLabel)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                    }
+
+                    HStack {
+                        Text(String(repeating: "•", count: min(account.sessionKey.count, 30)))
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
+
+                    Text(account.organizationName)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Divider()
+
+                Button(action: {
+                    grokAccountToDelete = account
+                    showDeleteGrokConfirmation = true
+                }) {
+                    HStack {
+                        Image(systemName: "trash.fill")
+                        Text(L.Account.deleteAccount)
+                    }
+                    .foregroundColor(.red)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Grok import / device login
+
+    var grokDeviceLoginCard: some View {
+        SettingCard(
+            icon: "sparkles",
+            iconColor: Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0),
+            title: L.Account.grokDeviceLogin,
+            hint: ""
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                if let code = grokDeviceUserCode {
+                    Text(L.Account.grokDeviceCodeHint)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(code)
+                        .font(.system(.title2, design: .monospaced))
+                        .fontWeight(.bold)
+                        .textSelection(.enabled)
+                    if let url = grokDeviceVerificationURL {
+                        Button(L.Account.grokOpenBrowser) {
+                            NSWorkspace.shared.open(url)
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    ProgressView()
+                        .scaleEffect(0.8)
+                    Button(L.Account.cancel) {
+                        grokDeviceCancel = true
+                        isGrokDeviceLogin = false
+                        grokDeviceUserCode = nil
+                        grokDeviceVerificationURL = nil
+                    }
+                    .buttonStyle(.bordered)
+                } else {
+                    ProgressView(L.Account.grokDevicePreparing)
+                }
+            }
+        }
+    }
+
+    func importGrokAuthJSON() {
+        isImportingGrokAuth = true
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedFileTypes = ["json"]
+        panel.directoryURL = GrokOAuthConfig.defaultAuthJSONPath.deletingLastPathComponent()
+        panel.nameFieldStringValue = "auth.json"
+        panel.message = L.Account.importGrokAuthHelp
+
+        panel.begin { response in
+            defer { isImportingGrokAuth = false }
+            guard response == .OK, let url = panel.url else { return }
+            do {
+                let tokens = try GrokOAuthService.importFromAuthJSON(at: url)
+                guard let refresh = tokens.refreshToken, !refresh.isEmpty else {
+                    validationError = UsageError.noCredentials.localizedDescription
+                    return
+                }
+                let account = Account(
+                    sessionKey: refresh,
+                    organizationId: tokens.teamId ?? tokens.userId ?? UUID().uuidString,
+                    organizationName: tokens.email ?? "Grok",
+                    provider: .grok
+                )
+                _ = settings.addGrokAccount(account)
+                successMessage = L.Account.grokImportSuccess
+            } catch {
+                validationError = error.localizedDescription
+            }
+        }
+    }
+
+    func startGrokDeviceLogin() {
+        grokDeviceCancel = false
+        isGrokDeviceLogin = true
+        grokDeviceUserCode = nil
+        grokDeviceVerificationURL = nil
+
+        GrokOAuthService.requestDeviceCode { result in
+            switch result {
+            case .failure(let error):
+                isGrokDeviceLogin = false
+                validationError = error.localizedDescription
+            case .success(let device):
+                grokDeviceUserCode = device.userCode
+                grokDeviceVerificationURL = device.verificationURIComplete ?? device.verificationURI
+                if let url = grokDeviceVerificationURL {
+                    NSWorkspace.shared.open(url)
+                }
+                GrokOAuthService.pollDeviceToken(
+                    deviceCode: device.deviceCode,
+                    interval: device.interval,
+                    expiresIn: device.expiresIn,
+                    shouldCancel: { grokDeviceCancel }
+                ) { pollResult in
+                    isGrokDeviceLogin = false
+                    grokDeviceUserCode = nil
+                    grokDeviceVerificationURL = nil
+                    switch pollResult {
+                    case .failure(let error):
+                        if !grokDeviceCancel {
+                            validationError = error.localizedDescription
+                        }
+                    case .success(let tokens):
+                        guard let refresh = tokens.refreshToken, !refresh.isEmpty else {
+                            validationError = UsageError.noCredentials.localizedDescription
+                            return
+                        }
+                        let account = Account(
+                            sessionKey: refresh,
+                            organizationId: tokens.teamId ?? tokens.userId ?? UUID().uuidString,
+                            organizationName: tokens.email ?? "Grok",
+                            provider: .grok
+                        )
+                        _ = settings.addGrokAccount(account)
+                        successMessage = L.Account.grokImportSuccess
+                    }
+                }
             }
         }
     }

--- a/Usage4Claude/Views/Settings/Tabs/AuthSettingsView.swift
+++ b/Usage4Claude/Views/Settings/Tabs/AuthSettingsView.swift
@@ -26,6 +26,13 @@ struct AuthSettingsView: View {
     @State var successMessage: String?
     @State var showDeleteCodexConfirmation = false
     @State var codexAccountToDelete: Account?
+    @State var showDeleteGrokConfirmation = false
+    @State var grokAccountToDelete: Account?
+    @State var isImportingGrokAuth = false
+    @State var isGrokDeviceLogin = false
+    @State var grokDeviceUserCode: String?
+    @State var grokDeviceVerificationURL: URL?
+    @State private var grokDeviceCancel = false
 
     var body: some View {
         ScrollView {
@@ -67,6 +74,15 @@ struct AuthSettingsView: View {
                         currentCodexAccountDetailView(account: currentCodexAccount)
                     }
 
+                    // Current Grok account detail
+                    if let currentGrokAccount = settings.currentGrokAccount {
+                        currentGrokAccountDetailView(account: currentGrokAccount)
+                    }
+
+                    if isGrokDeviceLogin {
+                        grokDeviceLoginCard
+                    }
+
                     // 说明卡片
                     howToCard
 
@@ -96,13 +112,25 @@ struct AuthSettingsView: View {
         } message: {
             Text(L.Account.deleteConfirmMessage)
         }
+        .alert(L.Account.deleteConfirmTitle, isPresented: $showDeleteGrokConfirmation) {
+            Button(L.Account.cancel, role: .cancel) {}
+            Button(L.Account.delete, role: .destructive) {
+                if let account = grokAccountToDelete {
+                    settings.removeGrokAccount(account)
+                }
+            }
+        } message: {
+            Text(L.Account.deleteConfirmMessage)
+        }
     }
 
     // MARK: - Account List View
 
     var accountListView: some View {
         let hasCodex = !settings.codexAccounts.isEmpty
-        let hasBothProviders = !settings.accounts.isEmpty && hasCodex
+        let hasGrok = !settings.grokAccounts.isEmpty
+        let providerCount = [!settings.accounts.isEmpty, hasCodex, hasGrok].filter { $0 }.count
+        let hasMultipleProviders = providerCount >= 2
 
         return SettingCard(
             icon: "person.2.fill",
@@ -111,7 +139,7 @@ struct AuthSettingsView: View {
             hint: ""
         ) {
             VStack(alignment: .leading, spacing: 12) {
-                if settings.accounts.isEmpty && settings.codexAccounts.isEmpty {
+                if settings.accounts.isEmpty && settings.codexAccounts.isEmpty && settings.grokAccounts.isEmpty {
                     // 无账户时的提示
                     VStack(spacing: 12) {
                         Image(systemName: "person.crop.circle.badge.plus")
@@ -126,7 +154,7 @@ struct AuthSettingsView: View {
                 } else {
                     // Claude 账户组
                     if !settings.accounts.isEmpty {
-                        if hasBothProviders {
+                        if hasMultipleProviders {
                             providerSectionHeader(provider: .claude, label: L.Account.claudeAccounts)
                         }
                         ForEach(settings.accounts) { account in
@@ -136,12 +164,23 @@ struct AuthSettingsView: View {
 
                     // Codex 账户组
                     if hasCodex {
-                        if hasBothProviders {
+                        if hasMultipleProviders {
                             providerSectionHeader(provider: .codex, label: L.Account.codexAccounts)
                                 .padding(.top, 4)
                         }
                         ForEach(settings.codexAccounts) { account in
                             accountRow(account: account, provider: .codex)
+                        }
+                    }
+
+                    // Grok accounts
+                    if hasGrok {
+                        if hasMultipleProviders {
+                            providerSectionHeader(provider: .grok, label: L.Account.grokAccounts)
+                                .padding(.top, 4)
+                        }
+                        ForEach(settings.grokAccounts) { account in
+                            accountRow(account: account, provider: .grok)
                         }
                     }
                 }
@@ -188,6 +227,22 @@ struct AuthSettingsView: View {
                 ) {
                     WebLoginWindowManager.shared.showCodexLoginWindow()
                 }
+
+                addAccountActionButton(
+                    provider: .grok,
+                    title: L.Account.importGrokAuth,
+                    help: L.Account.importGrokAuthHelp
+                ) {
+                    importGrokAuthJSON()
+                }
+
+                addAccountActionButton(
+                    provider: .grok,
+                    title: L.Account.grokDeviceLogin,
+                    help: L.Account.grokDeviceLoginHelp
+                ) {
+                    startGrokDeviceLogin()
+                }
             }
         }
         .padding(.top, 8)
@@ -233,6 +288,10 @@ struct AuthSettingsView: View {
                 Image(systemName: "sparkles")
                     .frame(width: size, height: size)
             }
+        case .grok:
+            Image(systemName: "sparkles")
+                .foregroundColor(Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0))
+                .frame(width: size, height: size)
         }
     }
 
@@ -246,6 +305,10 @@ struct AuthSettingsView: View {
                 Image(nsImage: icon)
                     .resizable()
                     .frame(width: 12, height: 12)
+            } else if provider == .grok {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 10))
+                    .foregroundColor(Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0))
             }
             Text(label)
                 .font(.caption)
@@ -259,18 +322,26 @@ struct AuthSettingsView: View {
     // MARK: - Account Row
 
     func accountRow(account: Account, provider: ProviderType) -> some View {
-        let isSelected = provider == .codex
-            ? account.id == settings.currentCodexAccountId
-            : account.id == settings.currentAccountId
-        let accentColor: Color = provider == .codex
-            ? Color(red: 45/255.0, green: 212/255.0, blue: 191/255.0)
-            : .blue
+        let isSelected: Bool = {
+            switch provider {
+            case .claude: return account.id == settings.currentAccountId
+            case .codex: return account.id == settings.currentCodexAccountId
+            case .grok: return account.id == settings.currentGrokAccountId
+            }
+        }()
+        let accentColor: Color = {
+            switch provider {
+            case .claude: return .blue
+            case .codex: return Color(red: 45/255.0, green: 212/255.0, blue: 191/255.0)
+            case .grok: return Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0)
+            }
+        }()
 
         return Button(action: {
-            if provider == .codex {
-                settings.switchToCodexAccount(account)
-            } else {
-                settings.switchToAccount(account)
+            switch provider {
+            case .claude: settings.switchToAccount(account)
+            case .codex: settings.switchToCodexAccount(account)
+            case .grok: settings.switchToGrokAccount(account)
             }
         }) {
             HStack(spacing: 12) {

--- a/Usage4Claude/Views/Settings/Tabs/GeneralSettingsDisplayOptionsSection.swift
+++ b/Usage4Claude/Views/Settings/Tabs/GeneralSettingsDisplayOptionsSection.swift
@@ -114,7 +114,7 @@ struct GeneralSettingsDisplayOptionsSection: View {
 
     /// 判断是否只剩一个圆形图标
     private var hasOnlyOneCircularIcon: Bool {
-        let circularTypes: Set<LimitType> = [.fiveHour, .sevenDay, .codexPrimary, .codexSecondary]
+        let circularTypes: Set<LimitType> = [.fiveHour, .sevenDay, .codexPrimary, .codexSecondary, .grokWeekly, .grokMonthly]
         let selectedCircular = settings.customDisplayTypes.intersection(circularTypes)
         return selectedCircular.count == 1
     }
@@ -135,7 +135,7 @@ struct GeneralSettingsDisplayOptionsSection: View {
         }
         #endif
 
-        let circularTypes: Set<LimitType> = [.fiveHour, .sevenDay, .codexPrimary, .codexSecondary]
+        let circularTypes: Set<LimitType> = [.fiveHour, .sevenDay, .codexPrimary, .codexSecondary, .grokWeekly, .grokMonthly]
 
         // 如果这是最后一个选中的圆形图标，则禁用
         if circularTypes.contains(limitType) {
@@ -226,6 +226,9 @@ struct LimitTypeCheckbox: View {
         case .codexPrimary:  return Color(red: 45/255.0, green: 212/255.0, blue: 191/255.0)
         case .codexSecondary: return Color(red: 96/255.0, green: 165/255.0, blue: 250/255.0)
         case .codexExtraUsage: return Color(red: 245/255.0, green: 158/255.0, blue: 11/255.0)
+        case .grokWeekly: return Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0)
+        case .grokMonthly: return Color(red: 244/255.0, green: 114/255.0, blue: 182/255.0)
+        case .grokCredits: return Color(red: 250/255.0, green: 204/255.0, blue: 21/255.0)
         }
     }
 }

--- a/Usage4Claude/Views/Settings/Welcome/SetupStepView.swift
+++ b/Usage4Claude/Views/Settings/Welcome/SetupStepView.swift
@@ -20,7 +20,7 @@ struct SetupStepView: View {
 
     /// 判断是否应该禁用某个checkbox
     private func shouldDisableCheckbox(for limitType: LimitType) -> Bool {
-        let circularTypes: Set<LimitType> = [.fiveHour, .sevenDay, .codexPrimary, .codexSecondary]
+        let circularTypes: Set<LimitType> = [.fiveHour, .sevenDay, .codexPrimary, .codexSecondary, .grokWeekly, .grokMonthly]
 
         // 如果这是最后一个选中的圆形图标，则禁用
         if circularTypes.contains(limitType) {

--- a/Usage4Claude/Views/UsageDetailView.swift
+++ b/Usage4Claude/Views/UsageDetailView.swift
@@ -13,8 +13,10 @@ import SwiftUI
 struct UsageDetailView: View {
     @Binding var usageData: UsageData?
     @Binding var codexUsageData: CodexUsageData?
+    @Binding var grokUsageData: GrokUsageData?
     @Binding var errorMessage: String?
     @Binding var codexErrorMessage: String?
+    @Binding var grokErrorMessage: String?
     /// Codex 三级刷新均失败，需要用户手动重新登录
     @Binding var codexNeedsRelogin: Bool
     @ObservedObject var refreshState: RefreshState
@@ -60,6 +62,7 @@ struct UsageDetailView: View {
         case refresh
         case refreshClaude
         case refreshCodex
+        case refreshGrok
         case codexRelogin
     }
     
@@ -77,18 +80,36 @@ struct UsageDetailView: View {
     @AppStorage("showRemainingMode") private var savedRemainingMode = false
     @State private var showRemainingMode = UserDefaults.standard.bool(forKey: "showRemainingMode")
     @State private var remainingModeAnimationTrigger = 0
+    @State var grokAnimationType: LoadingAnimationType = .rainbow
     
     // MARK: - Body
 
+    private var showsClaudeColumn: Bool {
+        usageData != nil || errorMessage != nil || UserSettings.shared.hasValidCredentials
+    }
+
+    private var showsCodexColumn: Bool {
+        codexUsageData != nil || codexErrorMessage != nil || UserSettings.shared.hasValidCodexCredentials
+    }
+
+    private var showsGrokColumn: Bool {
+        grokUsageData != nil || grokErrorMessage != nil || UserSettings.shared.hasValidGrokCredentials
+    }
+
+    private var visibleProviderCount: Int {
+        [showsClaudeColumn, showsCodexColumn, showsGrokColumn].filter { $0 }.count
+    }
+
     private var isMultiProviderActive: Bool {
-        UserSettings.shared.isMultiProviderActive
-            && (codexUsageData != nil || codexErrorMessage != nil || UserSettings.shared.hasValidCodexCredentials)
+        visibleProviderCount >= 2
     }
 
     private var isCodexOnlyActive: Bool {
-        !isMultiProviderActive
-            && ((!UserSettings.shared.hasValidCredentials && UserSettings.shared.hasValidCodexCredentials)
-                || (usageData == nil && (codexUsageData != nil || codexErrorMessage != nil)))
+        !isMultiProviderActive && showsCodexColumn && !showsClaudeColumn && !showsGrokColumn
+    }
+
+    private var isGrokOnlyActive: Bool {
+        !isMultiProviderActive && showsGrokColumn && !showsClaudeColumn && !showsCodexColumn
     }
 
     private var isClaudeRefreshing: Bool {
@@ -177,14 +198,14 @@ struct UsageDetailView: View {
     }
 
     private var contentWidth: CGFloat {
-        isMultiProviderActive ? 580 : 290
+        CGFloat(max(visibleProviderCount, 1)) * 290
     }
 
     private var contentHeight: CGFloat {
         if isMultiProviderActive {
             return multiProviderHeight
         }
-        if isCodexOnlyActive {
+        if isCodexOnlyActive || isGrokOnlyActive {
             return codexOnlyHeight
         }
         return dynamicHeight
@@ -546,13 +567,23 @@ struct UsageDetailView: View {
                     Image(systemName: "chart.pie.fill")
                         .foregroundColor(.blue)
                 }
-            } else if let icon = ImageHelper.createCodexIcon(size: headerIconSize) {
+            } else if provider == .codex, let icon = ImageHelper.createCodexIcon(size: headerIconSize) {
                 Image(nsImage: icon)
                     .resizable()
                     .frame(width: headerIconSize, height: headerIconSize)
+            } else if provider == .grok {
+                Image(systemName: "sparkles")
+                    .foregroundColor(Color(red: 100/255.0, green: 116/255.0, blue: 139/255.0))
+                    .frame(width: headerIconSize, height: headerIconSize)
             }
 
-            Text(provider == .claude ? L.Usage.title : L.Usage.codexTitle)
+            Text({
+                switch provider {
+                case .claude: return L.Usage.title
+                case .codex: return L.Usage.codexTitle
+                case .grok: return L.Usage.grokTitle
+                }
+            }())
                 .font(.headline)
 
             Spacer()
@@ -695,42 +726,101 @@ struct UsageDetailView: View {
         }
     }
 
-    private func multiProviderBody(codex: CodexUsageData?) -> some View {
+    private func multiProviderBody(codex: CodexUsageData?, grok: GrokUsageData?) -> some View {
         VStack(spacing: contentSpacing) {
             HStack(alignment: .top, spacing: 0) {
-                VStack(spacing: contentSpacing) {
-                    ZStack(alignment: .bottom) {
-                        VStack(spacing: contentSpacing) {
-                            headerView(provider: .claude, showsControls: false)
-                            claudeMainContent
-                        }
-                        .offset(y: isAnimationHintVisible(for: .claude) ? -18 : 0)
-                    }
-                    .overlay(alignment: .bottom) {
-                        animationHintOverlay(for: .claude)
+                if showsClaudeColumn {
+                    providerColumn(provider: .claude, showsControls: !showsCodexColumn && !showsGrokColumn) {
+                        claudeMainContent
                     }
                 }
-                .frame(width: 290, alignment: .top)
-
-                VStack(spacing: contentSpacing) {
-                    ZStack(alignment: .bottom) {
-                        VStack(spacing: contentSpacing) {
-                            headerView(provider: .codex, showsControls: true)
-                            codexOnlyMainContent(codex: codex)
-                        }
-                        .offset(y: isAnimationHintVisible(for: .codex) ? -18 : 0)
-                    }
-                    .overlay(alignment: .bottom) {
-                        animationHintOverlay(for: .codex)
+                if showsCodexColumn {
+                    providerColumn(provider: .codex, showsControls: true) {
+                        codexOnlyMainContent(codex: codex)
                     }
                 }
-                .frame(width: 290, alignment: .top)
-            }
-            .overlay(alignment: .center) {
-                ProviderDivider(height: multiProviderDividerHeight)
-                    .allowsHitTesting(false)
+                if showsGrokColumn {
+                    providerColumn(provider: .grok, showsControls: true) {
+                        grokOnlyMainContent(grok: grok)
+                    }
+                }
             }
 
+            updateNotificationView
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private func providerColumn<Content: View>(
+        provider: ProviderType,
+        showsControls: Bool,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(spacing: contentSpacing) {
+            ZStack(alignment: .bottom) {
+                VStack(spacing: contentSpacing) {
+                    headerView(provider: provider, showsControls: showsControls)
+                    content()
+                }
+                .offset(y: isAnimationHintVisible(for: provider) ? -18 : 0)
+            }
+            .overlay(alignment: .bottom) {
+                animationHintOverlay(for: provider)
+            }
+        }
+        .frame(width: 290, alignment: .top)
+    }
+
+    @ViewBuilder
+    private func grokOnlyMainContent(grok: GrokUsageData?) -> some View {
+        if let grok {
+            GrokColumnView(
+                grokUsageData: grok,
+                showRemainingMode: $showRemainingMode,
+                refreshState: refreshState,
+                animationType: $grokAnimationType,
+                rotationAngle: $rotationAngle,
+                remainingModeAnimationTrigger: remainingModeAnimationTrigger,
+                onRefresh: { onMenuAction?(.refreshGrok) },
+                onAnimationHint: { showAnimationHint($0, provider: .grok) },
+                onToggleRemainingMode: toggleRemainingMode
+            )
+        } else if let error = grokErrorMessage {
+            VStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 40))
+                    .foregroundColor(.orange)
+                Text(error)
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                Button(action: { onMenuAction?(.authSettings) }) {
+                    Label(L.Usage.goToSettings, systemImage: "key.fill")
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding()
+        } else {
+            ProgressView()
+                .padding()
+        }
+    }
+
+    private func grokOnlyBody(grok: GrokUsageData?) -> some View {
+        VStack(spacing: contentSpacing) {
+            VStack(spacing: contentSpacing) {
+                headerView(provider: .grok, showsControls: true)
+                grokOnlyMainContent(grok: grok)
+            }
+            .offset(y: isAnimationHintVisible(for: .grok) ? -18 : 0)
+
+            animationHintView(for: .grok)
             updateNotificationView
             Spacer()
         }
@@ -767,7 +857,9 @@ struct UsageDetailView: View {
     var body: some View {
         Group {
             if isMultiProviderActive {
-                multiProviderBody(codex: codexUsageData)
+                multiProviderBody(codex: codexUsageData, grok: grokUsageData)
+            } else if isGrokOnlyActive {
+                grokOnlyBody(grok: grokUsageData)
             } else if isCodexOnlyActive {
                 codexOnlyBody(codex: codexUsageData)
             } else {
@@ -777,6 +869,7 @@ struct UsageDetailView: View {
         .frame(width: contentWidth, height: contentHeight)
         .animation(.easeInOut(duration: 0.25), value: isMultiProviderActive)
         .animation(.easeInOut(duration: 0.25), value: isCodexOnlyActive)
+        .animation(.easeInOut(duration: 0.25), value: isGrokOnlyActive)
         .animation(.easeInOut(duration: 0.25), value: showAnimationTypeHint)
         .id(localization.updateTrigger)  // 语言变化时重新创建视图
         .onAppear {
@@ -879,7 +972,9 @@ struct UsageDetailView_Previews: PreviewProvider {
 
     @State static var errorMsg: String? = nil
     @State static var codexErrorMsg: String? = nil
+    @State static var grokErrorMsg: String? = nil
     @State static var codexData: CodexUsageData? = nil
+    @State static var grokData: GrokUsageData? = nil
     @State static var codexNeedsRelogin = false
     @StateObject static var refreshState = RefreshState()
     @State static var hasUpdate = false
@@ -889,8 +984,10 @@ struct UsageDetailView_Previews: PreviewProvider {
         UsageDetailView(
             usageData: $sampleData,
             codexUsageData: $codexData,
+            grokUsageData: $grokData,
             errorMessage: $errorMsg,
             codexErrorMessage: $codexErrorMsg,
+            grokErrorMessage: $grokErrorMsg,
             codexNeedsRelogin: $codexNeedsRelogin,
             refreshState: refreshState,
             hasAvailableUpdate: $hasUpdate,


### PR DESCRIPTION
## Summary

Adds optional **Grok Build / SuperGrok** usage monitoring as a third provider alongside Claude and Codex, addressing #69.

Closes #69

### What users get
- **Weekly** SuperGrok / Grok Build quota (`?format=credits` billing response)
- **Monthly** included allowance (default billing form)
- **Credits** residual (prepaid / on-demand)
- Menu bar icons + detail-window column (alone or next to Claude/Codex)
- Multi-account storage in Keychain (same pattern as Codex)

### Auth (Settings → Authentication)
1. **Import Grok Auth** — pick Grok CLI `~/.grok/auth.json` (recommended if you already run `grok login`)
2. **Grok Device Login** — OIDC device-code flow against `auth.x.ai` (public Grok CLI client id)

### Technical approach
Mirrors the existing Codex provider integration:

| Layer | Implementation |
|-------|----------------|
| Models | `ProviderType.grok`, `GrokUsageData` + billing response parsers |
| API | `GrokAPIService` — refresh_token → access_token → concurrent credits + monthly billing GETs |
| Auth | `GrokOAuthService` — token refresh, device code, auth.json import |
| Storage | `accounts_grok` Keychain list + `AccountStore` CRUD |
| UI | `GrokColumnView`, multi-column detail width, menu-bar composition |
| Limits | `grok_weekly` / `grok_monthly` / `grok_credits` colors, notifications, custom display |

Billing endpoints (same surface used by official Grok CLI `/usage`):
- `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`
- `GET https://cli-chat-proxy.grok.com/v1/billing`

## Tests

Repo already has a SwiftPM pure-function test target. Added:

- `Tests/Usage4ClaudeCoreTests/GrokUsageResponseTests.swift`
  - credits weekly % from `productUsage` / `creditUsagePercent` fallback
  - Grok product preference over other products
  - monthly used/limit percentage + edge cases (missing limit/used, zero limit)
  - percentage clamping, empty payloads
  - ISO8601 with/without fractional seconds
  - `GrokCreditsData` enabled / percentage rules
  - `ProviderType.grok` display name

Run (on a machine with Swift toolchain):

```bash
swift test
```

Full macOS app still builds via Xcode / `./scripts/build.sh`.

## Notes for reviewers
- Claude-only and Codex-only flows are unchanged until a Grok account is added.
- No Grok brand asset pack yet — menu bar uses a small synthetic “G” badge; can be swapped for real assets later.
- Device-code + auth.json import only (no embedded WKWebView for Grok); keeps parity with how Grok CLI authenticates and avoids reverse-engineering private web cookies.

## Test plan
- [ ] `swift test` passes (Grok parser suite + existing suites)
- [ ] Import `~/.grok/auth.json` → Grok column appears with weekly/monthly data
- [ ] Device-code login completes and persists account across relaunch
- [ ] Claude-only / Codex-only / Grok-only / multi-provider layouts look correct
- [ ] Manual refresh and smart refresh still work with Grok credentials present
- [ ] Custom display toggles for Grok weekly/monthly/credits work
- [ ] 90% usage notification fires for Grok weekly/monthly when enabled