### PR TITLE
fix: keep showing cached usage data on transient errors

### DIFF
--- a/Usage4Claude/App/MenuBarManager.swift
+++ b/Usage4Claude/App/MenuBarManager.swift
@@ -65,6 +65,8 @@ class MenuBarManager: ObservableObject {
     @Published var isLoading = false
     /// 错误消息（从 dataManager 同步）
     @Published var errorMessage: String?
+    /// 当前错误是否为认证类错误（从 dataManager 同步）
+    @Published var errorRequiresAuthAction = false
     /// Codex 错误消息（独立于 Claude）
     @Published var codexErrorMessage: String?
     /// Codex 三级刷新均失败，需要用户手动重新登录
@@ -117,6 +119,9 @@ class MenuBarManager: ObservableObject {
 
         dataManager.$errorMessage
             .assign(to: &$errorMessage)
+
+        dataManager.$errorRequiresAuthAction
+            .assign(to: &$errorRequiresAuthAction)
 
         dataManager.$codexErrorMessage
             .assign(to: &$codexErrorMessage)
@@ -333,6 +338,10 @@ class MenuBarManager: ObservableObject {
             errorMessage: Binding(
                 get: { self.errorMessage },
                 set: { self.errorMessage = $0 }
+            ),
+            errorRequiresAuthAction: Binding(
+                get: { self.errorRequiresAuthAction },
+                set: { _ in }
             ),
             codexErrorMessage: Binding(
                 get: { self.codexErrorMessage },

--- a/Usage4Claude/Helpers/DataRefreshManager.swift
+++ b/Usage4Claude/Helpers/DataRefreshManager.swift
@@ -36,6 +36,9 @@ class DataRefreshManager: ObservableObject {
     @Published var isLoading = false
     /// 错误消息
     @Published var errorMessage: String?
+    /// 当前 errorMessage 是否为需要用户处理的认证类错误（未授权/会话过期/未配置）。
+    /// 视图层据此决定：认证错误全屏提示引导去设置，瞬时错误（限流/网络）保留缓存数据只显示横幅
+    @Published var errorRequiresAuthAction = false
     /// Codex 错误消息（独立于 Claude，避免双 Provider 时被静默隐藏）
     @Published var codexErrorMessage: String?
     /// 刷新状态管理器
@@ -124,6 +127,7 @@ class DataRefreshManager: ObservableObject {
     func fetchUsage() {
         isLoading = true
         errorMessage = nil
+        errorRequiresAuthAction = false
         codexErrorMessage = nil
         lastAPIFetchTime = Date()
 
@@ -141,6 +145,7 @@ class DataRefreshManager: ObservableObject {
             isLoading = false
             endRefreshAnimationWithMinimumDuration { }
             errorMessage = UsageError.noCredentials.localizedDescription
+            errorRequiresAuthAction = true
             return
         }
 
@@ -191,6 +196,7 @@ class DataRefreshManager: ObservableObject {
                     let previousData = self.usageData
                     self.usageData = data
                     self.errorMessage = nil
+                    self.errorRequiresAuthAction = false
                     monitoringUtilizations[.claude] = data.percentage
 
                     if self.settings.notificationsEnabled {
@@ -208,6 +214,7 @@ class DataRefreshManager: ObservableObject {
 
                 case .failure(let error):
                     self.errorMessage = error.localizedDescription
+                    self.errorRequiresAuthAction = self.requiresAuthAction(error)
                     Logger.menuBar.error("Claude API 请求失败: \(error.localizedDescription)")
 
                 case .none:
@@ -223,6 +230,16 @@ class DataRefreshManager: ObservableObject {
         usageData = nil
         lastResetsAt = nil
         cancelResetVerification()
+    }
+
+    /// 判断错误是否需要用户去设置里处理认证信息（区别于限流/网络等可自愈的瞬时错误）
+    private func requiresAuthAction(_ error: Error) -> Bool {
+        switch error {
+        case UsageError.unauthorized, UsageError.sessionExpired, UsageError.noCredentials:
+            return true
+        default:
+            return false
+        }
     }
 
     private func clearCodexUsageState(clearError: Bool = true) {
@@ -458,6 +475,7 @@ class DataRefreshManager: ObservableObject {
         }
         isLoading = true
         errorMessage = nil
+        errorRequiresAuthAction = false
         lastAPIFetchTime = Date()
 
         // ClaudeAPIService.fetchUsage 保证 completion 一律在主线程回调，此处无需再包一层 DispatchQueue.main.async
@@ -471,6 +489,7 @@ class DataRefreshManager: ObservableObject {
                 let previousData = self.usageData
                 self.usageData = data
                 self.errorMessage = nil
+                self.errorRequiresAuthAction = false
                 if self.settings.notificationsEnabled {
                     NotificationManager.shared.checkAndNotify(usageData: data, previousData: previousData)
                 }
@@ -483,8 +502,9 @@ class DataRefreshManager: ObservableObject {
                 }
                 self.lastResetsAt = newResetsAt
             case .failure(let error):
-                self.clearClaudeUsageState()
+                // 保留缓存数据（与 fetchUsage 的失败路径一致），瞬时错误下 UI 只显示横幅
                 self.errorMessage = error.localizedDescription
+                self.errorRequiresAuthAction = self.requiresAuthAction(error)
                 Logger.menuBar.error("Claude API 请求失败: \(error.localizedDescription)")
             }
         }
@@ -644,6 +664,7 @@ class DataRefreshManager: ObservableObject {
         switch provider {
         case .claude:
             errorMessage = nil
+            errorRequiresAuthAction = false
             clearClaudeUsageState()
             if shouldFetchClaudeUsage {
                 fetchClaudeOnly()

--- a/Usage4Claude/Helpers/LocalizationHelper.swift
+++ b/Usage4Claude/Helpers/LocalizationHelper.swift
@@ -316,6 +316,7 @@ enum L {
         static var noOrganizationsFound: String { localized("error.no_organizations_found") }
         static var unauthorized: String { localized("error.unauthorized") }
         static var rateLimited: String { localized("error.rate_limited") }
+        static var showingCachedData: String { localized("error.showing_cached_data") }
     }
 
     // MARK: - Diagnostics

--- a/Usage4Claude/Resources/de.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/de.lproj/Localizable.strings
@@ -168,6 +168,7 @@
 "error.no_organizations_found" = "Keine Organisationen gefunden";
 "error.unauthorized" = "Anmeldung fehlgeschlagen, bitte die Anmeldedaten prüfen";
 "error.rate_limited" = "Zu viele Anfragen, bitte später erneut versuchen";
+"error.showing_cached_data" = "Letzte abgerufene Daten werden angezeigt";
 
 // MARK: - Launch at Login
 "launch.status.enabled" = "Aktiviert";

--- a/Usage4Claude/Resources/en.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/en.lproj/Localizable.strings
@@ -169,6 +169,7 @@
 "error.no_organizations_found" = "No organizations found";
 "error.unauthorized" = "Authentication failed, please check your credentials";
 "error.rate_limited" = "Too many requests, please try again later";
+"error.showing_cached_data" = "Showing last fetched data";
 
 // MARK: - Launch at Login
 "launch.status.enabled" = "Enabled";

--- a/Usage4Claude/Resources/fr.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/fr.lproj/Localizable.strings
@@ -169,6 +169,7 @@
 "error.no_organizations_found" = "Aucune organisation trouvée";
 "error.unauthorized" = "Échec de l'authentification, veuillez vérifier vos identifiants";
 "error.rate_limited" = "Trop de requêtes, veuillez réessayer plus tard";
+"error.showing_cached_data" = "Affichage des dernières données récupérées";
 
 // MARK: - Launch at Login
 "launch.status.enabled" = "Activé";

--- a/Usage4Claude/Resources/ja.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ja.lproj/Localizable.strings
@@ -169,6 +169,7 @@
 "error.no_organizations_found" = "組織が見つかりませんでした";
 "error.unauthorized" = "認証に失敗しました。認証情報を確認してください";
 "error.rate_limited" = "リクエストが多すぎます。しばらくしてから再試行してください";
+"error.showing_cached_data" = "最後に取得したデータを表示しています";
 
 // MARK: - Launch at Login
 "launch.status.enabled" = "有効";

--- a/Usage4Claude/Resources/ko.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ko.lproj/Localizable.strings
@@ -169,6 +169,7 @@
 "error.no_organizations_found" = "조직을 찾을 수 없습니다";
 "error.unauthorized" = "인증 실패, 자격 증명을 확인하세요";
 "error.rate_limited" = "요청이 너무 빈번합니다. 잠시 후 다시 시도하세요";
+"error.showing_cached_data" = "마지막으로 가져온 데이터를 표시 중";
 
 // MARK: - Launch at Login
 "launch.status.enabled" = "활성화됨";

--- a/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
@@ -169,6 +169,7 @@
 "error.no_organizations_found" = "未找到组织";
 "error.unauthorized" = "认证失败，请检查您的凭据";
 "error.rate_limited" = "请求过于频繁，请稍后再试";
+"error.showing_cached_data" = "显示上次获取的数据";
 
 // MARK: - Launch at Login
 "launch.status.enabled" = "已启用";

--- a/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
@@ -169,6 +169,7 @@
 "error.no_organizations_found" = "未找到組織";
 "error.unauthorized" = "認證失敗，請檢查您的憑據";
 "error.rate_limited" = "請求過於頻繁，請稍後再試";
+"error.showing_cached_data" = "顯示上次取得的資料";
 
 // MARK: - Launch at Login
 "launch.status.enabled" = "已啟用";

--- a/Usage4Claude/Views/UsageDetailView.swift
+++ b/Usage4Claude/Views/UsageDetailView.swift
@@ -14,6 +14,9 @@ struct UsageDetailView: View {
     @Binding var usageData: UsageData?
     @Binding var codexUsageData: CodexUsageData?
     @Binding var errorMessage: String?
+    /// 当前错误是否为认证类错误：认证错误全屏提示引导去设置；
+    /// 瞬时错误（限流/网络）在有缓存数据时保留数据展示，只显示顶部横幅
+    @Binding var errorRequiresAuthAction: Bool
     @Binding var codexErrorMessage: String?
     /// Codex 三级刷新均失败，需要用户手动重新登录
     @Binding var codexNeedsRelogin: Bool
@@ -180,20 +183,30 @@ struct UsageDetailView: View {
         isMultiProviderActive ? 580 : 290
     }
 
+    /// 瞬时错误横幅高度（两行 caption 文本 + 内边距）+ VStack 行距
+    private var staleBannerHeight: CGFloat {
+        showsStaleDataBanner ? 53 : 0
+    }
+
     private var contentHeight: CGFloat {
         if isMultiProviderActive {
-            return multiProviderHeight
+            return multiProviderHeight + staleBannerHeight
         }
         if isCodexOnlyActive {
             return codexOnlyHeight
         }
-        return dynamicHeight
+        return dynamicHeight + staleBannerHeight
+    }
+
+    /// 是否显示"数据已过期"横幅：有缓存数据的瞬时错误不清空界面，只提示
+    private var showsStaleDataBanner: Bool {
+        errorMessage != nil && usageData != nil && !errorRequiresAuthAction
     }
 
     @ViewBuilder
     private var claudeMainContent: some View {
-        if let error = errorMessage {
-            // 错误信息
+        if let error = errorMessage, usageData == nil || errorRequiresAuthAction {
+            // 错误信息（无缓存数据或认证类错误时才全屏展示）
             VStack(spacing: 12) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 40))
@@ -206,7 +219,7 @@ struct UsageDetailView: View {
                 // 操作按钮组
                 HStack(spacing: 12) {
                     // 如果是认证信息错误，显示设置按钮
-                    if error.contains("认证") || error.contains("配置") || error.contains("Authentication") || error.contains("configured") {
+                    if errorRequiresAuthAction {
                         Button(action: {
                             onMenuAction?(.authSettings)
                         }) {
@@ -238,6 +251,11 @@ struct UsageDetailView: View {
         } else if let data = usageData {
             // 使用数据
             VStack(spacing: 15) {
+                // 瞬时错误横幅：保留缓存数据展示，仅在顶部轻量提示
+                if showsStaleDataBanner, let error = errorMessage {
+                    staleDataBanner(error)
+                }
+
                 // 圆形进度条
                 ZStack {
                     let primaryLimitData = getPrimaryLimitData(data: data, activeTypes: activeDisplayTypes)
@@ -413,6 +431,34 @@ struct UsageDetailView: View {
             }
             .frame(height: 100)
         }
+    }
+
+    /// 瞬时错误（如 429 限流）横幅：错误文案单行截断，完整内容见悬停提示
+    @ViewBuilder
+    private func staleDataBanner(_ error: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 14))
+                .foregroundColor(.orange)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(error)
+                    .font(.caption)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Text(L.Error.showingCachedData)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.orange.opacity(0.12))
+        )
+        .padding(.horizontal, 14)
+        .help(error)
     }
 
     // MARK: - Header Buttons
@@ -878,6 +924,7 @@ struct UsageDetailView_Previews: PreviewProvider {
     )
 
     @State static var errorMsg: String? = nil
+    @State static var errorRequiresAuth = false
     @State static var codexErrorMsg: String? = nil
     @State static var codexData: CodexUsageData? = nil
     @State static var codexNeedsRelogin = false
@@ -890,6 +937,7 @@ struct UsageDetailView_Previews: PreviewProvider {
             usageData: $sampleData,
             codexUsageData: $codexData,
             errorMessage: $errorMsg,
+            errorRequiresAuthAction: $errorRequiresAuth,
             codexErrorMessage: $codexErrorMsg,
             codexNeedsRelogin: $codexNeedsRelogin,
             refreshState: refreshState,


### PR DESCRIPTION
## Problem

When a refresh fails, the popover replaces everything with a full-screen error view — even though the last successful fetch is still in memory (the menu bar icon keeps rendering it). A brief 429 rate limit or a network blip therefore looks like a hard failure:

- The full-screen error hides perfectly good cached data behind an orange triangle.
- All errors get the same treatment: a transient rate limit renders identically to "no credentials configured".

## Fix

- Show the full-screen error only when there is **no cached data** or the error **needs user action** (unauthorized / session expired / no credentials). Other errors keep the normal detail view and add a compact warning banner at the top: the error text plus a "Showing last fetched data" note (hover shows the full error).
- Track the error kind via a new `DataRefreshManager.errorRequiresAuthAction` published flag instead of string-matching the localized message (`error.contains("Authentication")`), which only worked in English and Chinese — as a side effect, the **Go to Settings** button in the error view now appears for auth errors in every language.
- `fetchClaudeOnly` no longer clears cached usage data on failure, matching the combined `fetchUsage` path (previously a failed single-provider refresh wiped the cache; a failed combined refresh kept it).
- New `error.showing_cached_data` string in all 7 localizations (en, de, fr, ja, ko, zh-Hans, zh-Hant) — non-English translations are machine-assisted, happy to adjust.

## Notes

- Popover height accounts for the banner (+53pt) in single- and multi-provider layouts; the Codex column is untouched.
- `swift test` passes (61 tests).
- Independent of #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)