### PR TITLE
feat: display usage for all saved accounts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,10 @@ let package = Package(
                 "Helpers/SensitiveDataRedactor.swift",
                 "Helpers/ResetTimeChange.swift",
                 "Helpers/NotificationDecisionEngine.swift",
-                "Models/CodexUsageData.swift"
+                "Models/CodexUsageData.swift",
+                "Models/Account.swift",
+                "Models/AccountUsageSnapshot.swift",
+                "Models/MenuBarAccountVisibility.swift"
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - **⚙️ Custom Display** - Manually select which limit types to display, supports any combination
 - **🎨 Smart Colors** - Automatic color changes based on usage, each limit type has its own color scheme
 - **🔔 Usage Notifications** - Warning notification at 90% usage, reset notification when quota resets
-- **👥 Multi-Account Management** - Support multiple Claude accounts / multiple organizations per account, plus independent Codex account management and quick switching
+- **👥 Multi-Account Management** - Monitor every saved Claude and Codex account together, choose which accounts appear in the menu bar, and keep quick switching for account-specific actions
 - **🧩 Codex Support** - Optional Codex quota monitoring; use Codex alone or show it alongside Claude in a dual-column view (add a Codex account in settings to enable)
 - **🌐 Built-in Browser Login** - Claude login automatically extracts Session Key; Codex uses built-in browser login for ChatGPT authentication
 - **🎨 Appearance Settings** - Support system default / light / dark appearance modes

--- a/Tests/Usage4ClaudeCoreTests/AccountUsageSnapshotTests.swift
+++ b/Tests/Usage4ClaudeCoreTests/AccountUsageSnapshotTests.swift
@@ -2,6 +2,29 @@ import XCTest
 @testable import Usage4ClaudeCore
 
 final class AccountUsageSnapshotTests: XCTestCase {
+    func testAccountRequestGuardRejectsStaleGenerationAndAccountSwitch() {
+        let accountId = UUID()
+
+        XCTAssertTrue(AccountRequestGuard.isCurrent(
+            accountId: accountId,
+            generation: 4,
+            currentAccountId: accountId,
+            currentGeneration: 4
+        ))
+        XCTAssertFalse(AccountRequestGuard.isCurrent(
+            accountId: accountId,
+            generation: 3,
+            currentAccountId: accountId,
+            currentGeneration: 4
+        ))
+        XCTAssertFalse(AccountRequestGuard.isCurrent(
+            accountId: accountId,
+            generation: 4,
+            currentAccountId: UUID(),
+            currentGeneration: 4
+        ))
+    }
+
     func testPlanKeepsEveryClaudeThenEveryCodexAccount() {
         let claude = (0..<12).map { account("Claude \($0)", provider: .claude) }
         let codex = (0..<9).map { account("Codex \($0)", provider: .codex) }

--- a/Tests/Usage4ClaudeCoreTests/AccountUsageSnapshotTests.swift
+++ b/Tests/Usage4ClaudeCoreTests/AccountUsageSnapshotTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+@testable import Usage4ClaudeCore
+
+final class AccountUsageSnapshotTests: XCTestCase {
+    func testPlanKeepsEveryClaudeThenEveryCodexAccount() {
+        let claude = (0..<12).map { account("Claude \($0)", provider: .claude) }
+        let codex = (0..<9).map { account("Codex \($0)", provider: .codex) }
+
+        let plan = AccountMenuBarPlan.make(
+            claudeAccounts: claude,
+            codexAccounts: codex
+        )
+
+        XCTAssertEqual(plan.count, 21)
+        XCTAssertEqual(
+            plan.map(\.provider),
+            Array(repeating: ProviderType.claude, count: 12)
+                + Array(repeating: ProviderType.codex, count: 9)
+        )
+    }
+
+    func testDuplicateCompactLabelsReceiveStableOrdinals() {
+        let accounts = [
+            account("Personal", provider: .claude),
+            account("Personal", provider: .claude)
+        ]
+
+        let labels = AccountMenuBarPlan.make(
+            claudeAccounts: accounts,
+            codexAccounts: []
+        ).map(\.label)
+
+        XCTAssertEqual(labels, ["Personal 1", "Personal 2"])
+    }
+
+    func testLabelsAreTruncatedByCharacters() {
+        let plan = AccountMenuBarPlan.make(
+            claudeAccounts: [account("Personal Account", provider: .claude)],
+            codexAccounts: [],
+            maxLabelLength: 8
+        )
+
+        XCTAssertEqual(plan.map(\.label), ["Personal"])
+    }
+
+    func testSnapshotKeepsAliasAndEmailAsSeparateIdentityFields() {
+        let account = Account(
+            sessionKey: "credential",
+            organizationId: "organization",
+            organizationName: "Personal workspace",
+            email: "owner@example.com",
+            alias: "Work",
+            provider: .claude
+        )
+
+        let snapshot = AccountUsageSnapshot(account: account)
+
+        XCTAssertEqual(snapshot.displayName, "Work")
+        XCTAssertEqual(snapshot.accountIdentity, "owner@example.com")
+        XCTAssertEqual(account.presentationLabel, "Work — owner@example.com")
+    }
+
+    func testSelectedProjectionUsesMatchingUUID() {
+        let first = account("One", provider: .claude)
+        let second = account("Two", provider: .claude)
+        let usage = UsageData(
+            fiveHour: .init(percentage: 42, resetsAt: nil),
+            sevenDay: nil,
+            weeklyModels: [],
+            extraUsage: nil
+        )
+        let snapshots = [
+            AccountUsageSnapshot(account: second, payload: .claude(usage))
+        ]
+
+        XCTAssertNil(snapshots.selectedClaude(accountId: first.id))
+        XCTAssertEqual(snapshots.selectedClaude(accountId: second.id)?.percentage, 42)
+    }
+
+    func testCredentialUpdateChangesOnlyMatchingAccount() {
+        let first = account("One", provider: .claude)
+        let second = account("Two", provider: .claude)
+
+        let updated = AccountCredentialUpdate.replacingCredential(
+            in: [first, second],
+            accountId: second.id,
+            token: "rotated-token"
+        )
+
+        XCTAssertEqual(updated[0].sessionKey, first.sessionKey)
+        XCTAssertEqual(updated[1].sessionKey, "rotated-token")
+        XCTAssertEqual(updated.map(\.id), [first.id, second.id])
+    }
+
+    func testCredentialUpdateDoesNotOverwriteNewerCredential() {
+        let account = account("One", provider: .claude)
+
+        let staleUpdate = AccountCredentialUpdate.replacingCredential(
+            in: [account],
+            accountId: account.id,
+            expectedToken: "already-replaced",
+            token: "late-refresh"
+        )
+        let validUpdate = AccountCredentialUpdate.replacingCredential(
+            in: [account],
+            accountId: account.id,
+            expectedToken: account.sessionKey,
+            token: "fresh-refresh"
+        )
+
+        XCTAssertEqual(staleUpdate[0].sessionKey, account.sessionKey)
+        XCTAssertEqual(validUpdate[0].sessionKey, "fresh-refresh")
+    }
+
+    func testReducerKeepsPreviousPayloadWhenOneAccountFails() {
+        let first = account("One", provider: .claude)
+        let second = account("Two", provider: .claude)
+        let previousUsage = claudeUsage(percentage: 20)
+        let freshUsage = claudeUsage(percentage: 70)
+        let plan = AccountMenuBarPlan.make(claudeAccounts: [first, second], codexAccounts: [])
+        let previous = [
+            AccountUsageSnapshot(account: first, payload: .claude(previousUsage)),
+            AccountUsageSnapshot(account: second, payload: .claude(previousUsage))
+        ]
+
+        let merged = AccountUsageReducer.merge(
+            plan: plan,
+            previous: previous,
+            results: [
+                first.id: .success(.claude(freshUsage)),
+                second.id: .failure("offline")
+            ]
+        )
+
+        XCTAssertEqual(merged.selectedClaude(accountId: first.id)?.percentage, 70)
+        XCTAssertEqual(merged.selectedClaude(accountId: second.id)?.percentage, 20)
+        XCTAssertEqual(merged.first(where: { $0.id == second.id })?.errorDescription, "offline")
+    }
+
+    func testReducerDropsAccountsNoLongerInPlan() {
+        let kept = account("Kept", provider: .claude)
+        let removed = account("Removed", provider: .claude)
+        let previous = [
+            AccountUsageSnapshot(account: kept, payload: .claude(claudeUsage(percentage: 10))),
+            AccountUsageSnapshot(account: removed, payload: .claude(claudeUsage(percentage: 20)))
+        ]
+
+        let merged = AccountUsageReducer.merge(
+            plan: AccountMenuBarPlan.make(claudeAccounts: [kept], codexAccounts: []),
+            previous: previous,
+            results: [:]
+        )
+
+        XCTAssertEqual(merged.map(\.id), [kept.id])
+    }
+
+    func testReducerPublishesPlanBeforeResultsWhileKeepingPreviousPayloads() {
+        let first = account("One", provider: .claude)
+        let second = account("Two", provider: .codex)
+        let previous = [
+            AccountUsageSnapshot(account: first, payload: .claude(claudeUsage(percentage: 10)))
+        ]
+        let plan = AccountMenuBarPlan.make(
+            claudeAccounts: [first],
+            codexAccounts: [second]
+        )
+
+        let merged = AccountUsageReducer.merge(plan: plan, previous: previous, results: [:])
+
+        XCTAssertEqual(merged.map(\.id), [first.id, second.id])
+        XCTAssertEqual(merged.selectedClaude(accountId: first.id)?.percentage, 10)
+        XCTAssertNil(merged.first(where: { $0.id == second.id })?.payload)
+    }
+
+    func testRenderSignatureIncludesEveryAccountAndChangesWithUsage() {
+        let first = account("One", provider: .claude)
+        let second = account("Two", provider: .claude)
+        let initial = [
+            AccountUsageSnapshot(account: first, payload: .claude(claudeUsage(percentage: 10))),
+            AccountUsageSnapshot(account: second, payload: .claude(claudeUsage(percentage: 20)))
+        ]
+        let changed = [
+            initial[0],
+            AccountUsageSnapshot(account: second, payload: .claude(claudeUsage(percentage: 21)))
+        ]
+
+        let initialSignature = AccountMenuBarSignature.make(snapshots: initial, hasUpdate: false)
+        let changedSignature = AccountMenuBarSignature.make(snapshots: changed, hasUpdate: false)
+
+        XCTAssertTrue(initialSignature.contains(first.id.uuidString))
+        XCTAssertTrue(initialSignature.contains(second.id.uuidString))
+        XCTAssertNotEqual(initialSignature, changedSignature)
+    }
+
+    private func claudeUsage(percentage: Double) -> UsageData {
+        UsageData(
+            fiveHour: .init(percentage: percentage, resetsAt: nil),
+            sevenDay: nil,
+            weeklyModels: [],
+            extraUsage: nil
+        )
+    }
+
+    private func account(_ name: String, provider: ProviderType) -> Account {
+        Account(
+            sessionKey: "credential-\(name)",
+            organizationId: "organization-\(name)",
+            organizationName: name,
+            provider: provider
+        )
+    }
+}

--- a/Tests/Usage4ClaudeCoreTests/MenuBarAccountVisibilityTests.swift
+++ b/Tests/Usage4ClaudeCoreTests/MenuBarAccountVisibilityTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Usage4ClaudeCore
+
+final class MenuBarAccountVisibilityTests: XCTestCase {
+    func testAccountsAreVisibleWhenNoPreferenceHasBeenSaved() {
+        let accountId = UUID()
+        let visibility = MenuBarAccountVisibility(persistedAccountIdStrings: nil)
+
+        XCTAssertTrue(visibility.isVisible(accountId: accountId))
+        XCTAssertTrue(visibility.hiddenAccountIds.isEmpty)
+    }
+
+    func testHidingAndShowingAnAccountUpdatesPersistedIDs() {
+        let accountId = UUID()
+        var visibility = MenuBarAccountVisibility(persistedAccountIdStrings: nil)
+
+        visibility.setVisibility(accountId: accountId, isVisible: false)
+        XCTAssertFalse(visibility.isVisible(accountId: accountId))
+        XCTAssertEqual(visibility.persistedAccountIdStrings, [accountId.uuidString])
+
+        visibility.setVisibility(accountId: accountId, isVisible: true)
+        XCTAssertTrue(visibility.isVisible(accountId: accountId))
+        XCTAssertTrue(visibility.persistedAccountIdStrings.isEmpty)
+    }
+
+    func testInvalidPersistedIDsAreIgnored() {
+        let accountId = UUID()
+        let visibility = MenuBarAccountVisibility(
+            persistedAccountIdStrings: ["not-a-uuid", accountId.uuidString]
+        )
+
+        XCTAssertEqual(visibility.hiddenAccountIds, [accountId])
+    }
+
+    func testRemovingAccountPrunesItsHiddenPreference() {
+        let hiddenId = UUID()
+        var visibility = MenuBarAccountVisibility(
+            persistedAccountIdStrings: [hiddenId.uuidString]
+        )
+
+        visibility.removeAccount(hiddenId)
+
+        XCTAssertTrue(visibility.hiddenAccountIds.isEmpty)
+    }
+}

--- a/Usage4Claude/App/MenuBarIconRenderer.swift
+++ b/Usage4Claude/App/MenuBarIconRenderer.swift
@@ -108,6 +108,119 @@ class MenuBarIconRenderer {
         return icon
     }
 
+    /// Creates one group per saved account. Unlike the legacy API,
+    /// this deliberately does not collapse accounts of the same provider.
+    func createIcon(
+        accountSnapshots: [AccountUsageSnapshot],
+        hasUpdate: Bool,
+        button: NSStatusBarButton?
+    ) -> NSImage {
+        guard !accountSnapshots.isEmpty else {
+            let divider = createMenuBarDividerIcon(isMonochrome: settings.iconStyleMode == .monochrome)
+            return hasUpdate ? addBadgeToImage(divider) : divider
+        }
+
+        let isMonochrome = resolvedMonochromeMode(for: accountSnapshots)
+        if settings.iconDisplayMode == .none {
+            let divider = createMenuBarDividerIcon(isMonochrome: isMonochrome)
+            return hasUpdate ? addBadgeToImage(divider) : divider
+        }
+        let groups = accountSnapshots.map {
+            createAccountGroup($0, isMonochrome: isMonochrome, button: button)
+        }
+
+        var icons: [NSImage] = []
+        for (index, group) in groups.enumerated() {
+            if index > 0 {
+                icons.append(createMenuBarDividerIcon(isMonochrome: isMonochrome))
+            }
+            icons.append(group)
+        }
+
+        var icon = combineIcons(icons, spacing: 3.0, height: metricIconSize)
+        icon.isTemplate = isMonochrome
+        if hasUpdate { icon = addBadgeToImage(icon) }
+        return icon
+    }
+
+    private func resolvedMonochromeMode(for snapshots: [AccountUsageSnapshot]) -> Bool {
+        if let claudeUsage = snapshots.compactMap({ snapshot -> UsageData? in
+            guard case .some(.claude(let usage)) = snapshot.payload else { return nil }
+            return usage
+        }).first {
+            let canUseColor = settings.canUseColoredTheme(usageData: claudeUsage)
+            let forceMonochrome = !canUseColor && settings.iconStyleMode != .monochrome
+            return settings.iconStyleMode == .monochrome || forceMonochrome
+        }
+        return settings.iconStyleMode == .monochrome
+    }
+
+    /// A complete account group includes a provider mark only when the selected
+    /// display mode requests icons. Status remains visible while usage loads or fails.
+    private func createAccountGroup(
+        _ snapshot: AccountUsageSnapshot,
+        isMonochrome: Bool,
+        button: NSStatusBarButton?
+    ) -> NSImage {
+        var icons: [NSImage] = []
+
+        switch settings.iconDisplayMode {
+        case .iconOnly, .both:
+            if let brand = createProviderBrandIcon(snapshot.provider, isMonochrome: isMonochrome, size: providerBrandIconSize) {
+                icons.append(brand)
+            }
+        case .percentageOnly, .none:
+            break
+        }
+        let metricIcons = createMetricIcons(for: snapshot, isMonochrome: isMonochrome, button: button)
+        icons.append(contentsOf: metricIcons)
+        if snapshot.errorDescription != nil {
+            icons.append(createAccountStatusIcon(for: snapshot, isMonochrome: isMonochrome))
+        } else if case .none = snapshot.payload {
+            icons.append(createAccountStatusIcon(for: snapshot, isMonochrome: isMonochrome))
+        }
+
+        let group = combineIcons(icons, spacing: 2.0, height: metricIconSize)
+        group.isTemplate = isMonochrome
+        return group
+    }
+
+    private func createMetricIcons(
+        for snapshot: AccountUsageSnapshot,
+        isMonochrome: Bool,
+        button: NSStatusBarButton?
+    ) -> [NSImage] {
+        guard settings.iconDisplayMode == .percentageOnly || settings.iconDisplayMode == .both else {
+            return []
+        }
+
+        switch snapshot.payload {
+        case .some(.claude(let usage)):
+            let types = settings.getActiveDisplayTypes(usageData: usage, forMenuBar: true)
+                .filter { $0.provider == .claude }
+            return types.compactMap {
+                createIconForType($0, data: usage, isMonochrome: isMonochrome, button: button)
+            }
+
+        case .some(.codex(let usage)):
+            let types = settings.getActiveDisplayTypes(usageData: nil, codexUsageData: usage, forMenuBar: true)
+                .filter { $0.provider == .codex }
+            return buildCodexIcons(codex: usage, types: types, isMonochrome: isMonochrome, button: button)
+
+        case .none:
+            return []
+        }
+    }
+
+    private func createAccountStatusIcon(for snapshot: AccountUsageSnapshot, isMonochrome: Bool) -> NSImage {
+        let symbolName = snapshot.errorDescription == nil ? "clock" : "exclamationmark.triangle"
+        let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: snapshot.errorDescription ?? "Loading usage")
+            ?? createSimpleCircleIcon()
+        image.size = NSSize(width: 13, height: 13)
+        image.isTemplate = isMonochrome
+        return image
+    }
+
     // MARK: - Multi-Provider Icon Creation
 
     /// 双 Provider 模式图标：[Claude 品牌] + [Claude 指标] + [Codex 品牌] + [Codex 指标]

--- a/Usage4Claude/App/MenuBarManager.swift
+++ b/Usage4Claude/App/MenuBarManager.swift
@@ -61,6 +61,8 @@ class MenuBarManager: ObservableObject {
     @Published var usageData: UsageData?
     /// Codex 用量数据（从 dataManager 同步）
     @Published var codexUsageData: CodexUsageData?
+    /// All saved accounts' usage snapshots, in the same provider-first order used by the menu bar.
+    @Published var accountUsageSnapshots: [AccountUsageSnapshot] = []
     /// 加载状态（从 dataManager 同步）
     @Published var isLoading = false
     /// 错误消息（从 dataManager 同步）
@@ -108,6 +110,13 @@ class MenuBarManager: ObservableObject {
         dataManager.$codexUsageData
             .sink { [weak self] data in
                 self?.codexUsageData = data
+                self?.updateMenuBarIcon()
+            }
+            .store(in: &cancellables)
+
+        dataManager.$accountUsageSnapshots
+            .sink { [weak self] snapshots in
+                self?.accountUsageSnapshots = snapshots
                 self?.updateMenuBarIcon()
             }
             .store(in: &cancellables)
@@ -329,6 +338,10 @@ class MenuBarManager: ObservableObject {
             codexUsageData: Binding(
                 get: { self.codexUsageData },
                 set: { self.codexUsageData = $0 }
+            ),
+            accountUsageSnapshots: Binding(
+                get: { self.accountUsageSnapshots },
+                set: { self.accountUsageSnapshots = $0 }
             ),
             errorMessage: Binding(
                 get: { self.errorMessage },
@@ -573,7 +586,15 @@ class MenuBarManager: ObservableObject {
 
     /// 更新菜单栏图标
     private func updateMenuBarIcon() {
-        ui.updateMenuBarIcon(usageData: usageData, codexUsageData: codexUsageData, hasUpdate: hasAvailableUpdate, shouldShowBadge: shouldShowUpdateBadge)
+        let visibleSnapshots = accountUsageSnapshots.filter {
+            settings.isAccountVisibleInMenuBar(id: $0.id)
+        }
+
+        ui.updateMenuBarIcon(
+            accountSnapshots: visibleSnapshots,
+            hasUpdate: hasAvailableUpdate,
+            shouldShowBadge: shouldShowUpdateBadge
+        )
     }
     
     // MARK: - Cleanup

--- a/Usage4Claude/App/MenuBarUI.swift
+++ b/Usage4Claude/App/MenuBarUI.swift
@@ -85,7 +85,7 @@ class MenuBarUI {
     private func setupPopover() {
         popover = NSPopover()
         // 固定尺寸以避免布局跳动
-        popover.contentSize = NSSize(width: 280, height: 240)
+        popover.contentSize = NSSize(width: 620, height: 560)
         // 设置行为，允许自定义外观
         popover.behavior = .semitransient
     }
@@ -578,6 +578,35 @@ class MenuBarUI {
         button.image = icon
     }
 
+    /// Updates the status item with every saved account in the supplied order.
+    /// The selected-account overload above remains for callers that have not
+    /// yet migrated to account-scoped refresh state.
+    func updateMenuBarIcon(accountSnapshots: [AccountUsageSnapshot], hasUpdate: Bool, shouldShowBadge: Bool) {
+        guard let button = statusItem.button else { return }
+
+        let showBadge = hasUpdate && shouldShowBadge
+        let cacheKey = generateCacheKey(accountSnapshots: accountSnapshots, hasUpdate: showBadge)
+
+        if let cachedImage = iconCache[cacheKey] {
+            button.image = cachedImage
+            return
+        }
+
+        let icon = iconRenderer.createIcon(
+            accountSnapshots: accountSnapshots,
+            hasUpdate: showBadge,
+            button: button
+        )
+
+        if iconCache.count >= maxCacheSize, !iconCacheOrder.isEmpty {
+            let oldestKey = iconCacheOrder.removeFirst()
+            iconCache.removeValue(forKey: oldestKey)
+        }
+        iconCache[cacheKey] = icon
+        iconCacheOrder.append(cacheKey)
+        button.image = icon
+    }
+
     /// 清除图标缓存
     func clearIconCache() {
         iconCache.removeAll()
@@ -659,6 +688,18 @@ class MenuBarUI {
         }
 
         return key
+    }
+
+    /// Account identity, label, provider, all displayed percentages, and the
+    /// per-account error state belong to the signature.  Settings are prefixed
+    /// because they change the renderer without changing a snapshot.
+    private func generateCacheKey(accountSnapshots: [AccountUsageSnapshot], hasUpdate: Bool) -> String {
+        let settingsKey = [
+            settings.iconDisplayMode.rawValue,
+            settings.iconStyleMode.rawValue,
+            settings.displayMode.rawValue
+        ].joined(separator: "_")
+        return "accounts_\(settingsKey)_\(AccountMenuBarSignature.make(snapshots: accountSnapshots, hasUpdate: hasUpdate))"
     }
 
     // MARK: - Utility Icons

--- a/Usage4Claude/Helpers/DataRefreshManager.swift
+++ b/Usage4Claude/Helpers/DataRefreshManager.swift
@@ -180,7 +180,7 @@ class DataRefreshManager: ObservableObject {
             guard let self, generation == self.refreshGeneration else { return }
             self.isLoading = false
             self.endRefreshAnimationWithMinimumDuration { }
-            self.apply(results: results, to: plan)
+            self.apply(results: results, to: plan, generation: generation)
         }
     }
 
@@ -211,7 +211,8 @@ class DataRefreshManager: ObservableObject {
     /// bindings for the popover, notifications, reset checks, and relogin UX.
     private func apply(
         results: [UUID: Result<AccountUsagePayload, Error>],
-        to plan: [AccountUsageSnapshot]
+        to plan: [AccountUsageSnapshot],
+        generation: Int
     ) {
         let previousSnapshots = accountUsageSnapshots
         accountUsageSnapshots = AccountUsageReducer.applying(
@@ -224,7 +225,11 @@ class DataRefreshManager: ObservableObject {
         let selectedClaudeId = settings.currentAccount?.id
         let selectedCodexId = settings.currentCodexAccount?.id
         applySelectedClaudeResult(selectedClaudeId.flatMap { results[$0] })
-        applySelectedCodexResult(selectedCodexId.flatMap { results[$0] })
+        applySelectedCodexResult(
+            selectedCodexId.flatMap { results[$0] },
+            accountId: selectedCodexId,
+            generation: generation
+        )
         updateSmartMonitoringFromSnapshots()
         pruneUnusedServices(using: plan)
         pruneResetVerifications(validAccountIds: Set(plan.map(\.id)))
@@ -293,7 +298,11 @@ class DataRefreshManager: ObservableObject {
         }
     }
 
-    private func applySelectedCodexResult(_ result: Result<AccountUsagePayload, Error>?) {
+    private func applySelectedCodexResult(
+        _ result: Result<AccountUsagePayload, Error>?,
+        accountId: UUID?,
+        generation: Int
+    ) {
         switch result {
         case .success(.codex(let data)):
             processCodexSuccess(data)
@@ -303,8 +312,13 @@ class DataRefreshManager: ObservableObject {
             // is intentionally retained only for the selected account.
             codexUsageData = accountUsageSnapshots.selectedCodex(accountId: settings.currentCodexAccount?.id)
             if case UsageError.unauthorized = error {
-                selectedCodexAPIService?.clearAccessTokenCache()
-                attemptTokenRefreshAndRetry()
+                guard let accountId,
+                      let account = settings.codexAccounts.first(where: { $0.id == accountId }) else {
+                    markCodexNeedsRelogin()
+                    return
+                }
+                codexAPIService(for: account.id).clearAccessTokenCache()
+                attemptTokenRefreshAndRetry(for: account, generation: generation)
             } else {
                 codexErrorMessage = error.localizedDescription
                 Logger.menuBar.info("Codex 请求失败（不影响其它账户）: \(error.localizedDescription)")
@@ -600,16 +614,25 @@ class DataRefreshManager: ObservableObject {
     /// Retry used after the selected account's legacy silent-refresh flow. It is
     /// intentionally scoped to that account and does not restart the provider-wide
     /// loop or a second unauthorized fallback chain.
-    private func fetchSelectedCodexUsageWithoutFallback(_ account: Account) {
+    private func fetchSelectedCodexUsageWithoutFallback(
+        _ account: Account,
+        generation: Int? = nil
+    ) {
         isLoading = true
         codexErrorMessage = nil
         lastAPIFetchTime = Date()
         let service = codexAPIService(for: account.id)
-        let generation = refreshGeneration
+        let generation = generation ?? refreshGeneration
 
         Task { @MainActor [weak self] in
             let result = await service.fetchUsageResult(for: account)
-            guard let self, generation == self.refreshGeneration else { return }
+            guard let self,
+                  AccountRequestGuard.isCurrent(
+                    accountId: account.id,
+                    generation: generation,
+                    currentAccountId: self.settings.currentCodexAccountId,
+                    currentGeneration: self.refreshGeneration
+                  ) else { return }
             self.isLoading = false
             self.endRefreshAnimationWithMinimumDuration { }
 
@@ -645,7 +668,8 @@ class DataRefreshManager: ObservableObject {
         }
     }
 
-    private func attemptTokenRefreshAndRetry() {
+    private func attemptTokenRefreshAndRetry(for account: Account, generation: Int) {
+        guard isCurrentCodexRequest(account: account, generation: generation) else { return }
         guard !codexNeedsRelogin else {
             Logger.menuBar.info("Codex 已确认需要重新登录，跳过刷新")
             markCodexNeedsRelogin()
@@ -653,10 +677,6 @@ class DataRefreshManager: ObservableObject {
         }
         // OAuth 账户：refresh_token 已在 fetchUsage 内尝试续期，401 表示 refresh_token 失效。
         // 旧的 chatgpt.com 三级刷新链针对 session-token，对 OAuth 凭据无意义且必然失败，直接要求重新登录。
-        guard let account = settings.currentCodexAccount else {
-            markCodexNeedsRelogin()
-            return
-        }
         if CodexAPIService.isOAuthRefreshToken(account.sessionKey) {
             Logger.menuBar.info("Codex OAuth refresh_token 失效，需重新登录")
             markCodexNeedsRelogin()
@@ -664,40 +684,41 @@ class DataRefreshManager: ObservableObject {
         }
         let prefix = account.sessionKey.prefix(16)
         Logger.menuBar.info("Codex accessToken 已过期，启动三级刷新链（session prefix=\(prefix)…）")
-        attemptLevel1SSRRefresh()
+        attemptLevel1SSRRefresh(for: account, generation: generation)
     }
 
     /// 级别 1：SSR bootstrap 刷新 accessToken
-    private func attemptLevel1SSRRefresh() {
+    private func attemptLevel1SSRRefresh(for account: Account, generation: Int) {
         Logger.menuBar.info("Codex 级别1：SSR bootstrap 刷新")
         Task { @MainActor [weak self] in
-            guard let self else { return }
-            CodexTokenRefreshCoordinator.shared.refresh { [weak self] result in
-                guard let self else { return }
+            guard let self, self.isCurrentCodexRequest(account: account, generation: generation) else { return }
+            CodexTokenRefreshCoordinator.shared.refresh(for: account) { [weak self] result in
+                guard let self, self.isCurrentCodexRequest(account: account, generation: generation) else { return }
                 switch result {
                 case .success(let freshAccessToken):
                     Logger.menuBar.notice("Codex 级别1 SSR 刷新成功，用新 accessToken 重试")
-                    self.retryCodexWithAccessToken(freshAccessToken)
+                    self.retryCodexWithAccessToken(freshAccessToken, for: account, generation: generation)
                 case .failure(let error):
                     Logger.menuBar.info("Codex 级别1 失败（\(error.localizedDescription)），降级至级别2")
-                    self.attemptLevel2WebViewRefresh()
+                    self.attemptLevel2WebViewRefresh(for: account, generation: generation)
                 }
             }
         }
     }
 
     /// 级别 2：隐藏 WebView 静默续期 session-token
-    private func attemptLevel2WebViewRefresh() {
+    private func attemptLevel2WebViewRefresh(for account: Account, generation: Int) {
         Logger.menuBar.info("Codex 级别2：隐藏 WebView 静默续期")
         Task { @MainActor [weak self] in
-            guard let self else { return }
-            CodexSilentRefreshCoordinator.shared.refresh { [weak self] result in
-                guard let self else { return }
+            guard let self, self.isCurrentCodexRequest(account: account, generation: generation) else { return }
+            CodexSilentRefreshCoordinator.shared.refresh(for: account) { [weak self] result in
+                guard let self, self.isCurrentCodexRequest(account: account, generation: generation) else { return }
                 switch result {
                 case .success:
                     Logger.menuBar.notice("Codex 级别2 WebView 续期成功，重新拉取用量")
                     // session-token 已在 coordinator 内写回，重新走完整的 session→usage 流程
-                    self.fetchCodexOnly(retryOnUnauthorized: false)
+                    guard let refreshedAccount = self.settings.codexAccounts.first(where: { $0.id == account.id }) else { return }
+                    self.fetchSelectedCodexUsageWithoutFallback(refreshedAccount, generation: generation)
                 case .failure(let error):
                     Logger.menuBar.error("Codex 级别2 失败（\(error.localizedDescription)），进入级别3")
                     self.markCodexNeedsRelogin()
@@ -707,16 +728,16 @@ class DataRefreshManager: ObservableObject {
     }
 
     /// 用新鲜 accessToken 直接查询用量（跳过 session 步骤）
-    private func retryCodexWithAccessToken(_ accessToken: String) {
+    private func retryCodexWithAccessToken(
+        _ accessToken: String,
+        for account: Account,
+        generation: Int
+    ) {
+        guard isCurrentCodexRequest(account: account, generation: generation) else { return }
         isLoading = true
-        guard let account = settings.currentCodexAccount else {
-            markCodexNeedsRelogin()
-            return
-        }
-        let generation = refreshGeneration
         codexAPIService(for: account.id).fetchUsageWithAccessToken(accessToken) { [weak self] usageResult in
             DispatchQueue.main.async {
-                guard let self, generation == self.refreshGeneration else { return }
+                guard let self, self.isCurrentCodexRequest(account: account, generation: generation) else { return }
                 self.isLoading = false
                 self.endRefreshAnimationWithMinimumDuration { }
                 switch usageResult {
@@ -730,10 +751,19 @@ class DataRefreshManager: ObservableObject {
                     self.processCodexSuccess(data)
                 case .failure(let error):
                     Logger.menuBar.error("Codex 新鲜 accessToken 仍失败: \(error.localizedDescription)，降级至级别2")
-                    self.attemptLevel2WebViewRefresh()
+                    self.attemptLevel2WebViewRefresh(for: account, generation: generation)
                 }
             }
         }
+    }
+
+    private func isCurrentCodexRequest(account: Account, generation: Int) -> Bool {
+        AccountRequestGuard.isCurrent(
+            accountId: account.id,
+            generation: generation,
+            currentAccountId: settings.currentCodexAccountId,
+            currentGeneration: refreshGeneration
+        )
     }
 
     private func replaceSelectedCodexSnapshot(account: Account, data: CodexUsageData) {

--- a/Usage4Claude/Helpers/DataRefreshManager.swift
+++ b/Usage4Claude/Helpers/DataRefreshManager.swift
@@ -17,10 +17,11 @@ class DataRefreshManager: ObservableObject {
 
     // MARK: - Dependencies
 
-    /// Claude API 服务实例
-    private let apiService = ClaudeAPIService()
-    /// Codex API 服务实例
-    private let codexApiService = CodexAPIService()
+    /// API clients are kept per account. The provider clients cancel an earlier
+    /// request on the same instance, so sharing one client would make concurrent
+    /// account refreshes cancel each other.
+    private var claudeAPIServices: [UUID: ClaudeAPIService] = [:]
+    private var codexAPIServices: [UUID: CodexAPIService] = [:]
     /// 定时器管理器
     private let timerManager = TimerManager()
     /// 用户设置实例
@@ -32,6 +33,9 @@ class DataRefreshManager: ObservableObject {
     @Published var usageData: UsageData?
     /// Codex 用量数据（nil 表示无 Codex 账号或拉取失败）
     @Published var codexUsageData: CodexUsageData?
+    /// Most recent usage for every saved account, ordered with Claude accounts first.
+    /// A failed refresh retains the account's last successful payload and updates only its error state.
+    @Published private(set) var accountUsageSnapshots: [AccountUsageSnapshot] = []
     /// 加载状态
     @Published var isLoading = false
     /// 错误消息
@@ -43,14 +47,15 @@ class DataRefreshManager: ObservableObject {
 
     // MARK: - Private State
 
-    /// Claude 上次的重置时间（用于检测重置是否完成）
-    private var lastResetsAt: Date?
-    /// Codex 上次的重置时间
-    private var lastCodexResetsAt: Date?
+    /// Reset verification is account-scoped so one account cannot cancel another account's checks.
+    private var resetVerificationDates: [UUID: Date] = [:]
     /// 上次手动刷新时间
     private var lastManualRefreshTime: Date?
     /// 上次API请求时间
     private var lastAPIFetchTime: Date?
+    /// Monotonically increasing request generation prevents a cancelled, older
+    /// refresh from publishing errors after a newer refresh has completed.
+    private var refreshGeneration = 0
     /// 刷新动画开始时间（用于确保动画最小显示时长）
     private var refreshAnimationStartTime: Date?
     /// 动画最小显示时长（秒）
@@ -64,17 +69,6 @@ class DataRefreshManager: ObservableObject {
     @Published private(set) var codexNeedsRelogin = false
     /// Codex 过期通知已发送，防止重复打扰
     private var codexSessionExpiredNotified = false
-
-    private var shouldFetchClaudeUsage: Bool {
-        #if DEBUG
-        if shouldSuppressDebugClaudeUsageForDisplayOptions {
-            return false
-        }
-        return settings.debugModeEnabled || settings.hasValidCredentials
-        #else
-        return settings.hasValidCredentials
-        #endif
-    }
 
     private var shouldSuppressDebugClaudeUsageForDisplayOptions: Bool {
         #if DEBUG
@@ -98,15 +92,18 @@ class DataRefreshManager: ObservableObject {
         #endif
     }
 
-    private var shouldFetchCodexUsage: Bool {
-        #if DEBUG
-        if shouldSuppressDebugCodexUsageForDisplayOptions {
-            return false
+    private func accountMenuBarPlan() -> [AccountUsageSnapshot] {
+        AccountMenuBarPlan.make(
+            claudeAccounts: settings.claudeAccounts,
+            codexAccounts: settings.codexAccounts
+        ).filter { snapshot in
+            switch snapshot.provider {
+            case .claude:
+                return !shouldSuppressDebugClaudeUsageForDisplayOptions
+            case .codex:
+                return !shouldSuppressDebugCodexUsageForDisplayOptions
+            }
         }
-        return settings.debugModeEnabled || settings.hasValidCodexCredentials
-        #else
-        return settings.hasValidCodexCredentials
-        #endif
     }
 
     /// 定时器标识符统一定义在 TimerManager.Identifier，避免两处各自为政
@@ -120,109 +117,237 @@ class DataRefreshManager: ObservableObject {
 
     // MARK: - Data Fetching
 
-    /// 获取用量数据（Claude + Codex 并发）
-    func fetchUsage() {
+    /// Fetches every account by default; a provider-only refresh leaves the other provider's snapshots unchanged.
+    func fetchUsage(provider: ProviderType? = nil) {
+        refreshGeneration += 1
+        let generation = refreshGeneration
         isLoading = true
-        errorMessage = nil
-        codexErrorMessage = nil
+        if provider == nil || provider == .claude { errorMessage = nil }
+        if provider == nil || provider == .codex { codexErrorMessage = nil }
         lastAPIFetchTime = Date()
 
-        let fetchClaude = shouldFetchClaudeUsage
-        let fetchCodex = shouldFetchCodexUsage
+        let plan = accountMenuBarPlan()
+        let accountsToFetch = provider.map { requestedProvider in
+            plan.filter { $0.provider == requestedProvider }
+        } ?? plan
 
-        if !fetchClaude {
+        guard !plan.isEmpty else {
+            accountUsageSnapshots = []
             clearClaudeUsageState()
-        }
-        if !fetchCodex {
             clearCodexUsageState()
-        }
-
-        guard fetchClaude || fetchCodex else {
             isLoading = false
             endRefreshAnimationWithMinimumDuration { }
             errorMessage = UsageError.noCredentials.localizedDescription
             return
         }
 
-        // Claude 与 Codex 并发拉取：两个子任务立即启动，结果在 MainActor 上顺序 await 合并
-        // （审计报告 4.2：替代 DispatchGroup + 跨线程共享可变结果变量的旧写法）
-        let claudeTask: Task<Result<UsageData, Error>, Never>? =
-            fetchClaude ? Task { await self.apiService.fetchUsageResult() } : nil
-        let codexTask: Task<Result<CodexUsageData, Error>, Never>? =
-            fetchCodex ? Task { await self.codexApiService.fetchUsageResult() } : nil
+        // Publish the current account plan before any request completes so the
+        // menu bar and popover can represent every account during the initial load.
+        // The reducer preserves each account's last known payload and error state.
+        accountUsageSnapshots = AccountUsageReducer.merge(
+            plan: plan,
+            previous: accountUsageSnapshots,
+            results: [:]
+        )
+
+        // One dedicated service instance per account keeps the existing client-side
+        // cancellation semantics local to that account while all accounts fetch together.
+        let tasks: [Task<(UUID, Result<AccountUsagePayload, Error>), Never>] = accountsToFetch.compactMap { descriptor in
+            guard let account = account(for: descriptor.id, provider: descriptor.provider) else { return nil }
+            switch account.provider {
+            case .claude:
+                let service = claudeAPIService(for: account.id)
+                return Task {
+                    let result = await service.fetchUsageResult(for: account)
+                    return (account.id, result.map(AccountUsagePayload.claude))
+                }
+            case .codex:
+                let service = codexAPIService(for: account.id)
+                return Task {
+                    let result = await service.fetchUsageResult(for: account)
+                    return (account.id, result.map(AccountUsagePayload.codex))
+                }
+            }
+        }
 
         Task { @MainActor [weak self] in
-            let claudeResult = await claudeTask?.value
-            let codexResult = await codexTask?.value
+            var results: [UUID: Result<AccountUsagePayload, Error>] = [:]
+            for task in tasks {
+                let (accountId, result) = await task.value
+                results[accountId] = result
+            }
 
-            guard let self = self else { return }
+            guard let self, generation == self.refreshGeneration else { return }
             self.isLoading = false
             self.endRefreshAnimationWithMinimumDuration { }
-
-            var monitoringUtilizations: [ProviderType: Double] = [:]
-            if fetchCodex {
-                switch codexResult {
-                case .success(let codex):
-                    if let utilization = self.monitoringUtilization(for: codex) {
-                        monitoringUtilizations[.codex] = utilization
-                    }
-                    self.processCodexSuccess(codex)
-
-                case .failure(let error):
-                    Logger.menuBar.info("Codex 请求失败（不影响主功能）: \(error.localizedDescription)")
-                    if case UsageError.unauthorized = error {
-                        self.attemptTokenRefreshAndRetry()
-                    } else {
-                        self.codexErrorMessage = error.localizedDescription
-                        self.clearCodexUsageState(clearError: false)
-                    }
-
-                case .none:
-                    self.clearCodexUsageState()
-                }
-            } else {
-                self.clearCodexUsageState()
-            }
-
-            // 处理 Claude 结果
-            if fetchClaude {
-                switch claudeResult {
-                case .success(let data):
-                    let previousData = self.usageData
-                    self.usageData = data
-                    self.errorMessage = nil
-                    monitoringUtilizations[.claude] = data.percentage
-
-                    if self.settings.notificationsEnabled {
-                        NotificationManager.shared.checkAndNotify(usageData: data, previousData: previousData)
-                    }
-
-                    let newResetsAt = data.resetsAt
-                    let hasResetChanged = hasResetTimeChanged(from: self.lastResetsAt, to: newResetsAt)
-                    if hasResetChanged {
-                        self.cancelResetVerification()
-                    } else if let resetsAt = newResetsAt {
-                        self.scheduleResetVerification(resetsAt: resetsAt)
-                    }
-                    self.lastResetsAt = newResetsAt
-
-                case .failure(let error):
-                    self.errorMessage = error.localizedDescription
-                    Logger.menuBar.error("Claude API 请求失败: \(error.localizedDescription)")
-
-                case .none:
-                    break
-                }
-            }
-
-            self.settings.updateSmartMonitoringMode(providerUtilizations: monitoringUtilizations)
+            self.apply(results: results, to: plan)
         }
+    }
+
+    private func account(for id: UUID, provider: ProviderType) -> Account? {
+        switch provider {
+        case .claude:
+            settings.claudeAccounts.first { $0.id == id }
+        case .codex:
+            settings.codexAccounts.first { $0.id == id }
+        }
+    }
+
+    private func claudeAPIService(for accountId: UUID) -> ClaudeAPIService {
+        if let service = claudeAPIServices[accountId] { return service }
+        let service = ClaudeAPIService()
+        claudeAPIServices[accountId] = service
+        return service
+    }
+
+    private func codexAPIService(for accountId: UUID) -> CodexAPIService {
+        if let service = codexAPIServices[accountId] { return service }
+        let service = CodexAPIService()
+        codexAPIServices[accountId] = service
+        return service
+    }
+
+    /// Atomically publish the all-account state, then preserve the existing selected-account
+    /// bindings for the popover, notifications, reset checks, and relogin UX.
+    private func apply(
+        results: [UUID: Result<AccountUsagePayload, Error>],
+        to plan: [AccountUsageSnapshot]
+    ) {
+        let previousSnapshots = accountUsageSnapshots
+        accountUsageSnapshots = AccountUsageReducer.applying(
+            results,
+            to: previousSnapshots,
+            plan: plan
+        )
+        processSuccessfulResults(results, previousSnapshots: previousSnapshots)
+
+        let selectedClaudeId = settings.currentAccount?.id
+        let selectedCodexId = settings.currentCodexAccount?.id
+        applySelectedClaudeResult(selectedClaudeId.flatMap { results[$0] })
+        applySelectedCodexResult(selectedCodexId.flatMap { results[$0] })
+        updateSmartMonitoringFromSnapshots()
+        pruneUnusedServices(using: plan)
+        pruneResetVerifications(validAccountIds: Set(plan.map(\.id)))
+    }
+
+    private func processSuccessfulResults(
+        _ results: [UUID: Result<AccountUsagePayload, Error>],
+        previousSnapshots: [AccountUsageSnapshot]
+    ) {
+        let previousPayloads = Dictionary(uniqueKeysWithValues: previousSnapshots.map { ($0.id, $0.payload) })
+
+        for (accountId, result) in results {
+            guard case .success(let payload) = result else { continue }
+
+            switch payload {
+            case .claude(let usage):
+                let previous: UsageData?
+                if case .claude(let value)? = previousPayloads[accountId] {
+                    previous = value
+                } else {
+                    previous = nil
+                }
+                if settings.notificationsEnabled {
+                    NotificationManager.shared.checkAndNotify(
+                        accountId: accountId,
+                        usageData: usage,
+                        previousData: previous
+                    )
+                }
+                reconcileResetVerification(accountId: accountId, resetsAt: usage.resetsAt)
+
+            case .codex(let usage):
+                let previous: CodexUsageData?
+                if case .codex(let value)? = previousPayloads[accountId] {
+                    previous = value
+                } else {
+                    previous = nil
+                }
+                if settings.notificationsEnabled {
+                    NotificationManager.shared.checkAndNotify(
+                        accountId: accountId,
+                        codexUsageData: usage,
+                        previousData: previous
+                    )
+                }
+                reconcileResetVerification(accountId: accountId, resetsAt: usage.primary?.resetsAt)
+            }
+        }
+    }
+
+    private func applySelectedClaudeResult(_ result: Result<AccountUsagePayload, Error>?) {
+        switch result {
+        case .success(.claude(let data)):
+            usageData = data
+            errorMessage = nil
+
+        case .failure(let error):
+            // The reducer has already retained any last good payload for this account.
+            usageData = accountUsageSnapshots.selectedClaude(accountId: settings.currentAccount?.id)
+            errorMessage = error.localizedDescription
+            Logger.menuBar.error("Claude API 请求失败: \(error.localizedDescription)")
+
+        case .success, .none:
+            usageData = accountUsageSnapshots.selectedClaude(accountId: settings.currentAccount?.id)
+            if settings.currentAccount == nil { clearClaudeUsageState() }
+        }
+    }
+
+    private func applySelectedCodexResult(_ result: Result<AccountUsagePayload, Error>?) {
+        switch result {
+        case .success(.codex(let data)):
+            processCodexSuccess(data)
+
+        case .failure(let error):
+            // Non-selected Codex errors never reach this path. The legacy 401 fallback
+            // is intentionally retained only for the selected account.
+            codexUsageData = accountUsageSnapshots.selectedCodex(accountId: settings.currentCodexAccount?.id)
+            if case UsageError.unauthorized = error {
+                selectedCodexAPIService?.clearAccessTokenCache()
+                attemptTokenRefreshAndRetry()
+            } else {
+                codexErrorMessage = error.localizedDescription
+                Logger.menuBar.info("Codex 请求失败（不影响其它账户）: \(error.localizedDescription)")
+            }
+
+        case .success, .none:
+            codexUsageData = accountUsageSnapshots.selectedCodex(accountId: settings.currentCodexAccount?.id)
+            if settings.currentCodexAccount == nil { clearCodexUsageState() }
+        }
+    }
+
+    private var selectedCodexAPIService: CodexAPIService? {
+        guard let accountId = settings.currentCodexAccount?.id else { return nil }
+        return codexAPIServices[accountId]
+    }
+
+    private func updateSmartMonitoringFromSnapshots() {
+        var utilizations: [ProviderType: Double] = [:]
+        for snapshot in accountUsageSnapshots {
+            let utilization: Double?
+            switch snapshot.payload {
+            case .claude(let usage):
+                utilization = usage.percentage
+            case .codex(let usage):
+                utilization = monitoringUtilization(for: usage)
+            case .none:
+                utilization = nil
+            }
+            if let utilization {
+                utilizations[snapshot.provider] = max(utilizations[snapshot.provider] ?? 0, utilization)
+            }
+        }
+        settings.updateSmartMonitoringMode(providerUtilizations: utilizations)
+    }
+
+    private func pruneUnusedServices(using plan: [AccountUsageSnapshot]) {
+        let validIDs = Set(plan.map(\.id))
+        claudeAPIServices = claudeAPIServices.filter { validIDs.contains($0.key) }
+        codexAPIServices = codexAPIServices.filter { validIDs.contains($0.key) }
     }
 
     private func clearClaudeUsageState() {
         usageData = nil
-        lastResetsAt = nil
-        cancelResetVerification()
     }
 
     private func clearCodexUsageState(clearError: Bool = true) {
@@ -230,8 +355,6 @@ class DataRefreshManager: ObservableObject {
         if clearError {
             codexErrorMessage = nil
         }
-        lastCodexResetsAt = nil
-        cancelCodexResetVerification()
     }
 
     private func monitoringUtilization(for codex: CodexUsageData) -> Double? {
@@ -294,7 +417,8 @@ class DataRefreshManager: ObservableObject {
     /// 启动 Codex accessToken 独立续期计时器（固定10分钟，与用量拉取解耦）
     private func startCodexTokenRefreshTimer() {
         timerManager.schedule(TimerID.codexTokenRefresh, interval: 10 * 60, repeats: true) { [weak self] in
-            self?.codexApiService.proactivelyRefreshIfNeeded()
+            guard let self, let account = self.settings.currentCodexAccount else { return }
+            self.codexAPIService(for: account.id).proactivelyRefreshIfNeeded()
         }
     }
 
@@ -409,7 +533,7 @@ class DataRefreshManager: ObservableObject {
 
     /// 仅刷新 Claude 数据（Claude 圆环点击触发）
     func handleClaudeOnlyRefresh() {
-        guard shouldFetchClaudeUsage else { return }
+        guard !settings.claudeAccounts.isEmpty else { return }
         let now = Date()
         if let lastManual = lastManualRefreshTime,
            now.timeIntervalSince(lastManual) < 10 { return }
@@ -432,7 +556,7 @@ class DataRefreshManager: ObservableObject {
 
     /// 仅刷新 Codex 数据（Codex 圆环点击触发）
     func handleCodexOnlyRefresh() {
-        guard shouldFetchCodexUsage else {
+        guard !settings.codexAccounts.isEmpty else {
             clearCodexUsageState()
             return
         }
@@ -452,94 +576,73 @@ class DataRefreshManager: ObservableObject {
     }
 
     private func fetchClaudeOnly() {
-        guard shouldFetchClaudeUsage else {
+        guard !settings.claudeAccounts.isEmpty else {
             clearClaudeUsageState()
             return
         }
-        isLoading = true
-        errorMessage = nil
-        lastAPIFetchTime = Date()
-
-        // ClaudeAPIService.fetchUsage 保证 completion 一律在主线程回调，此处无需再包一层 DispatchQueue.main.async
-        apiService.fetchUsage { [weak self] result in
-            guard let self = self else { return }
-            self.isLoading = false
-            self.endRefreshAnimationWithMinimumDuration { }
-
-            switch result {
-            case .success(let data):
-                let previousData = self.usageData
-                self.usageData = data
-                self.errorMessage = nil
-                if self.settings.notificationsEnabled {
-                    NotificationManager.shared.checkAndNotify(usageData: data, previousData: previousData)
-                }
-                self.settings.updateSmartMonitoringMode(providerUtilizations: [.claude: data.percentage])
-                let newResetsAt = data.resetsAt
-                if hasResetTimeChanged(from: self.lastResetsAt, to: newResetsAt) {
-                    self.cancelResetVerification()
-                } else if let resetsAt = newResetsAt {
-                    self.scheduleResetVerification(resetsAt: resetsAt)
-                }
-                self.lastResetsAt = newResetsAt
-            case .failure(let error):
-                self.clearClaudeUsageState()
-                self.errorMessage = error.localizedDescription
-                Logger.menuBar.error("Claude API 请求失败: \(error.localizedDescription)")
-            }
-        }
+        fetchUsage(provider: .claude)
     }
 
     private func fetchCodexOnly(retryOnUnauthorized: Bool = true) {
-        guard shouldFetchCodexUsage else {
+        guard !settings.codexAccounts.isEmpty else {
             clearCodexUsageState()
             return
         }
+        // A failed selected-account retry must not fan out into another fallback loop.
+        // The all-account refresh still retains each account's last good payload.
+        if retryOnUnauthorized {
+            fetchUsage(provider: .codex)
+        } else if let account = settings.currentCodexAccount {
+            fetchSelectedCodexUsageWithoutFallback(account)
+        }
+    }
+
+    /// Retry used after the selected account's legacy silent-refresh flow. It is
+    /// intentionally scoped to that account and does not restart the provider-wide
+    /// loop or a second unauthorized fallback chain.
+    private func fetchSelectedCodexUsageWithoutFallback(_ account: Account) {
         isLoading = true
         codexErrorMessage = nil
         lastAPIFetchTime = Date()
+        let service = codexAPIService(for: account.id)
+        let generation = refreshGeneration
 
-        codexApiService.fetchUsage { [weak self] result in
-            DispatchQueue.main.async {
-                guard let self = self else { return }
-                self.isLoading = false
-                self.endRefreshAnimationWithMinimumDuration { }
+        Task { @MainActor [weak self] in
+            let result = await service.fetchUsageResult(for: account)
+            guard let self, generation == self.refreshGeneration else { return }
+            self.isLoading = false
+            self.endRefreshAnimationWithMinimumDuration { }
 
-                switch result {
-                case .success(let data):
-                    self.processCodexSuccess(data)
-                case .failure(let error):
-                    if retryOnUnauthorized, case UsageError.unauthorized = error {
-                        // 401 说明缓存的 accessToken 已失效，立即清除避免下次继续用坏 token
-                        self.codexApiService.clearAccessTokenCache()
-                        self.attemptTokenRefreshAndRetry()
-                    } else {
-                        self.codexErrorMessage = error.localizedDescription
-                        self.clearCodexUsageState(clearError: false)
-                        Logger.menuBar.info("Codex 请求失败: \(error.localizedDescription)")
-                    }
-                }
+            let plan = self.accountMenuBarPlan()
+            let payloadResult = result.map(AccountUsagePayload.codex)
+            let previousSnapshots = self.accountUsageSnapshots
+            self.accountUsageSnapshots = AccountUsageReducer.applying(
+                [account.id: payloadResult],
+                to: previousSnapshots,
+                plan: plan
+            )
+            self.processSuccessfulResults(
+                [account.id: payloadResult],
+                previousSnapshots: previousSnapshots
+            )
+
+            switch result {
+            case .success(let data):
+                self.processCodexSuccess(data)
+            case .failure(let error):
+                self.codexUsageData = self.accountUsageSnapshots.selectedCodex(accountId: account.id)
+                self.codexErrorMessage = error.localizedDescription
+                Logger.menuBar.info("Codex 重试失败: \(error.localizedDescription)")
             }
         }
     }
 
     private func processCodexSuccess(_ data: CodexUsageData) {
-        let previousCodexData = codexUsageData
         codexUsageData = data
         codexErrorMessage = nil
         if let utilization = monitoringUtilization(for: data) {
             settings.updateSmartMonitoringMode(providerUtilizations: [.codex: utilization])
         }
-        if settings.notificationsEnabled {
-            NotificationManager.shared.checkAndNotify(codexUsageData: data, previousData: previousCodexData)
-        }
-        let newCodexResetsAt = data.primary?.resetsAt
-        if hasResetTimeChanged(from: lastCodexResetsAt, to: newCodexResetsAt) {
-            cancelCodexResetVerification()
-        } else if let resetsAt = newCodexResetsAt {
-            scheduleCodexResetVerification(resetsAt: resetsAt)
-        }
-        lastCodexResetsAt = newCodexResetsAt
     }
 
     private func attemptTokenRefreshAndRetry() {
@@ -550,12 +653,16 @@ class DataRefreshManager: ObservableObject {
         }
         // OAuth 账户：refresh_token 已在 fetchUsage 内尝试续期，401 表示 refresh_token 失效。
         // 旧的 chatgpt.com 三级刷新链针对 session-token，对 OAuth 凭据无意义且必然失败，直接要求重新登录。
-        if CodexAPIService.isOAuthRefreshToken(UserSettings.shared.codexSessionToken) {
+        guard let account = settings.currentCodexAccount else {
+            markCodexNeedsRelogin()
+            return
+        }
+        if CodexAPIService.isOAuthRefreshToken(account.sessionKey) {
             Logger.menuBar.info("Codex OAuth refresh_token 失效，需重新登录")
             markCodexNeedsRelogin()
             return
         }
-        let prefix = UserSettings.shared.codexSessionToken.prefix(16)
+        let prefix = account.sessionKey.prefix(16)
         Logger.menuBar.info("Codex accessToken 已过期，启动三级刷新链（session prefix=\(prefix)…）")
         attemptLevel1SSRRefresh()
     }
@@ -602,13 +709,24 @@ class DataRefreshManager: ObservableObject {
     /// 用新鲜 accessToken 直接查询用量（跳过 session 步骤）
     private func retryCodexWithAccessToken(_ accessToken: String) {
         isLoading = true
-        codexApiService.fetchUsageWithAccessToken(accessToken) { [weak self] usageResult in
+        guard let account = settings.currentCodexAccount else {
+            markCodexNeedsRelogin()
+            return
+        }
+        let generation = refreshGeneration
+        codexAPIService(for: account.id).fetchUsageWithAccessToken(accessToken) { [weak self] usageResult in
             DispatchQueue.main.async {
-                guard let self else { return }
+                guard let self, generation == self.refreshGeneration else { return }
                 self.isLoading = false
                 self.endRefreshAnimationWithMinimumDuration { }
                 switch usageResult {
                 case .success(let data):
+                    let previousSnapshots = self.accountUsageSnapshots
+                    self.replaceSelectedCodexSnapshot(account: account, data: data)
+                    self.processSuccessfulResults(
+                        [account.id: .success(.codex(data))],
+                        previousSnapshots: previousSnapshots
+                    )
                     self.processCodexSuccess(data)
                 case .failure(let error):
                     Logger.menuBar.error("Codex 新鲜 accessToken 仍失败: \(error.localizedDescription)，降级至级别2")
@@ -616,6 +734,15 @@ class DataRefreshManager: ObservableObject {
                 }
             }
         }
+    }
+
+    private func replaceSelectedCodexSnapshot(account: Account, data: CodexUsageData) {
+        let plan = accountMenuBarPlan()
+        accountUsageSnapshots = AccountUsageReducer.applying(
+            [account.id: .success(.codex(data))],
+            to: accountUsageSnapshots,
+            plan: plan
+        )
     }
 
     /// 重置重登状态（用户主动刷新时调用，允许再次尝试三级刷新链）
@@ -634,26 +761,31 @@ class DataRefreshManager: ObservableObject {
             }
         }
         codexErrorMessage = UsageError.sessionExpired.localizedDescription
-        clearCodexUsageState(clearError: false)
+        // Keep the selected account's last good usage visible while its re-login
+        // prompt is shown; the snapshot reducer owns stale-data retention.
+        codexUsageData = accountUsageSnapshots.selectedCodex(accountId: settings.currentCodexAccount?.id)
         Logger.menuBar.error("Codex 三级刷新均已失败，需要用户重新登录")
     }
 
     /// 账户切换后只清理并刷新对应 Provider，避免跨账号 previousData 误判重置。
     /// 通知去重状态按账号隔离，切换账号时保留，删除账号时再由 UserSettings 精准清理。
     func handleAccountChanged(provider: ProviderType?) {
+        refreshGeneration += 1
+        reconcileSnapshotsWithCurrentAccounts()
+
         switch provider {
         case .claude:
             errorMessage = nil
             clearClaudeUsageState()
-            if shouldFetchClaudeUsage {
+            if !settings.claudeAccounts.isEmpty {
                 fetchClaudeOnly()
             }
 
         case .codex:
             resetCodexReloginState()
-            codexApiService.clearAccessTokenCache()
+            selectedCodexAPIService?.clearAccessTokenCache()
             clearCodexUsageState()
-            if shouldFetchCodexUsage {
+            if !settings.codexAccounts.isEmpty {
                 fetchCodexOnly()
             }
 
@@ -663,6 +795,17 @@ class DataRefreshManager: ObservableObject {
             NotificationManager.shared.resetAllNotificationStates()
             fetchUsage()
         }
+    }
+
+    private func reconcileSnapshotsWithCurrentAccounts() {
+        let plan = accountMenuBarPlan()
+        accountUsageSnapshots = AccountUsageReducer.merge(
+            plan: plan,
+            previous: accountUsageSnapshots,
+            results: [:]
+        )
+        pruneUnusedServices(using: plan)
+        pruneResetVerifications(validAccountIds: Set(plan.map(\.id)))
     }
 
     /// 结束刷新动画，确保至少显示最小时长
@@ -699,84 +842,43 @@ class DataRefreshManager: ObservableObject {
 
     // MARK: - Reset Verification
 
-    /// 取消所有重置验证定时器
-    private func cancelResetVerification() {
-        timerManager.invalidate(TimerID.resetVerify1)
-        timerManager.invalidate(TimerID.resetVerify2)
-        timerManager.invalidate(TimerID.resetVerify3)
-    }
-
-    /// 安排重置时间验证
-    /// 在重置时间过后的1秒、10秒、30秒分别触发一次刷新
-    /// - Parameter resetsAt: 用量重置时间
-    private func scheduleResetVerification(resetsAt: Date) {
-        // 清除旧的验证定时器
-        cancelResetVerification()
-
-        // 计算距离重置时间的间隔
-        let timeUntilReset = resetsAt.timeIntervalSinceNow
-
-        // 只有重置时间在未来才安排验证
-        guard timeUntilReset > 0 else {
-            Logger.menuBar.debug("重置时间已过，跳过验证安排")
+    private func reconcileResetVerification(accountId: UUID, resetsAt: Date?) {
+        guard let resetsAt, resetsAt.timeIntervalSinceNow > 0 else {
+            cancelResetVerification(for: accountId)
             return
         }
+        guard resetVerificationDates[accountId] != resetsAt else { return }
 
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss"
-        formatter.timeZone = TimeZone.current
-        Logger.menuBar.debug("安排重置验证 - 重置时间: \(formatter.string(from: resetsAt))")
-
-        // 重置后1秒验证
-        timerManager.schedule(TimerID.resetVerify1, interval: timeUntilReset + 1, repeats: false) { [weak self] in
-            Logger.menuBar.debug("重置验证 +1秒 - 开始刷新")
-            self?.fetchUsage()
-        }
-
-        // 重置后10秒验证
-        timerManager.schedule(TimerID.resetVerify2, interval: timeUntilReset + 10, repeats: false) { [weak self] in
-            Logger.menuBar.debug("重置验证 +10秒 - 开始刷新")
-            self?.fetchUsage()
-        }
-
-        // 重置后30秒验证
-        timerManager.schedule(TimerID.resetVerify3, interval: timeUntilReset + 30, repeats: false) { [weak self] in
-            Logger.menuBar.debug("重置验证 +30秒 - 开始刷新")
-            self?.fetchUsage()
-        }
-    }
-
-    // MARK: - Codex Reset Verification
-
-    private func cancelCodexResetVerification() {
-        timerManager.invalidate(TimerID.codexResetVerify1)
-        timerManager.invalidate(TimerID.codexResetVerify2)
-        timerManager.invalidate(TimerID.codexResetVerify3)
-    }
-
-    private func scheduleCodexResetVerification(resetsAt: Date) {
-        cancelCodexResetVerification()
-
+        cancelResetVerification(for: accountId)
+        resetVerificationDates[accountId] = resetsAt
         let timeUntilReset = resetsAt.timeIntervalSinceNow
-        guard timeUntilReset > 0 else {
-            Logger.menuBar.debug("Codex 重置时间已过，跳过验证安排")
-            return
+        for offset in [1.0, 10.0, 30.0] {
+            timerManager.schedule(
+                resetVerificationTimerID(accountId: accountId, offset: offset),
+                interval: timeUntilReset + offset,
+                repeats: false
+            ) { [weak self] in
+                self?.fetchUsage()
+            }
         }
+    }
 
-        timerManager.schedule(TimerID.codexResetVerify1, interval: timeUntilReset + 1, repeats: false) { [weak self] in
-            Logger.menuBar.debug("Codex 重置验证 +1秒 - 开始刷新")
-            self?.fetchUsage()
+    private func pruneResetVerifications(validAccountIds: Set<UUID>) {
+        let removedAccountIds = resetVerificationDates.keys.filter { !validAccountIds.contains($0) }
+        for accountId in removedAccountIds {
+            cancelResetVerification(for: accountId)
         }
+    }
 
-        timerManager.schedule(TimerID.codexResetVerify2, interval: timeUntilReset + 10, repeats: false) { [weak self] in
-            Logger.menuBar.debug("Codex 重置验证 +10秒 - 开始刷新")
-            self?.fetchUsage()
+    private func cancelResetVerification(for accountId: UUID) {
+        for offset in [1.0, 10.0, 30.0] {
+            timerManager.invalidate(resetVerificationTimerID(accountId: accountId, offset: offset))
         }
+        resetVerificationDates.removeValue(forKey: accountId)
+    }
 
-        timerManager.schedule(TimerID.codexResetVerify3, interval: timeUntilReset + 30, repeats: false) { [weak self] in
-            Logger.menuBar.debug("Codex 重置验证 +30秒 - 开始刷新")
-            self?.fetchUsage()
-        }
+    private func resetVerificationTimerID(accountId: UUID, offset: Double) -> String {
+        "resetVerify.\(accountId.uuidString).\(Int(offset))"
     }
 
     // MARK: - Cleanup

--- a/Usage4Claude/Helpers/LocalizationHelper.swift
+++ b/Usage4Claude/Helpers/LocalizationHelper.swift
@@ -95,6 +95,8 @@ enum L {
         static var menubarHint: String { localized("settings.general.menubar_hint") }
         static var menubarTheme: String { localized("settings.general.menubar_theme") }
         static var displayContent: String { localized("settings.general.display_content") }
+        static var menuBarAccounts: String { localized("settings.general.menu_bar_accounts") }
+        static var menuBarAccountsHint: String { localized("settings.general.menu_bar_accounts_hint") }
         static var monochromeNoIconHint: String { localized("settings.general.monochrome_no_icon_hint") }
         static var refreshSection: String { localized("settings.general.refresh_section") }
         static var refreshMode: String { localized("settings.general.refresh_mode") }

--- a/Usage4Claude/Models/Account.swift
+++ b/Usage4Claude/Models/Account.swift
@@ -13,6 +13,8 @@ struct Account: Codable, Identifiable, Equatable {
     var sessionKey: String
     var organizationId: String
     var organizationName: String
+    /// Stable account identity shown outside the menu bar when it is available.
+    var email: String?
     var alias: String?
     let createdAt: Date
     var provider: ProviderType
@@ -24,10 +26,25 @@ struct Account: Codable, Identifiable, Equatable {
         return organizationName
     }
 
+    /// A duplicate-safe identity for settings and detail views.
+    var presentationLabel: String {
+        let identity = accountIdentity
+        guard identity != displayName else { return displayName }
+        return "\(displayName) — \(identity)"
+    }
+
+    /// Uses the verified email when available, then preserves legacy organization labels.
+    var accountIdentity: String {
+        if let email, !email.isEmpty {
+            return email
+        }
+        return organizationName
+    }
+
     // MARK: - CodingKeys
 
     private enum CodingKeys: String, CodingKey {
-        case id, sessionKey, organizationId, organizationName, alias, createdAt, provider
+        case id, sessionKey, organizationId, organizationName, email, alias, createdAt, provider
     }
 
     // MARK: - Codable
@@ -39,6 +56,7 @@ struct Account: Codable, Identifiable, Equatable {
         sessionKey = try container.decode(String.self, forKey: .sessionKey)
         organizationId = try container.decode(String.self, forKey: .organizationId)
         organizationName = try container.decode(String.self, forKey: .organizationName)
+        email = try container.decodeIfPresent(String.self, forKey: .email)
         alias = try container.decodeIfPresent(String.self, forKey: .alias)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         provider = try container.decodeIfPresent(ProviderType.self, forKey: .provider) ?? .claude
@@ -50,6 +68,7 @@ struct Account: Codable, Identifiable, Equatable {
         sessionKey: String,
         organizationId: String,
         organizationName: String,
+        email: String? = nil,
         alias: String? = nil,
         provider: ProviderType = .claude
     ) {
@@ -57,6 +76,7 @@ struct Account: Codable, Identifiable, Equatable {
         self.sessionKey = sessionKey
         self.organizationId = organizationId
         self.organizationName = organizationName
+        self.email = email
         self.alias = alias
         self.createdAt = Date()
         self.provider = provider
@@ -67,6 +87,7 @@ struct Account: Codable, Identifiable, Equatable {
         sessionKey: String,
         organizationId: String,
         organizationName: String,
+        email: String? = nil,
         alias: String?,
         createdAt: Date,
         provider: ProviderType = .claude
@@ -75,6 +96,7 @@ struct Account: Codable, Identifiable, Equatable {
         self.sessionKey = sessionKey
         self.organizationId = organizationId
         self.organizationName = organizationName
+        self.email = email
         self.alias = alias
         self.createdAt = createdAt
         self.provider = provider

--- a/Usage4Claude/Models/AccountStore.swift
+++ b/Usage4Claude/Models/AccountStore.swift
@@ -17,6 +17,9 @@ final class AccountStore: ObservableObject {
 
     private let defaults = UserDefaults.standard
     private let keychain = KeychainManager.shared
+    /// Whole-list Keychain writes must complete in mutation order. Concurrent writes can otherwise
+    /// persist an older account snapshot after a newer token rotation.
+    private let persistenceQueue = DispatchQueue(label: "xyz.fi5h.Usage4Claude.account-persistence")
 
     // MARK: - Claude 账户
 
@@ -215,7 +218,7 @@ final class AccountStore: ObservableObject {
     private func saveAccounts() {
         // 在调用线程（主线程）快照，避免后台队列直接读取主线程持有的可变数组造成数据竞争
         let snapshot = accounts
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        persistenceQueue.async { [weak self] in
             self?.keychain.saveAccounts(snapshot)
         }
     }
@@ -238,9 +241,7 @@ final class AccountStore: ObservableObject {
         }
         Logger.settings.notice("添加账户: \(account.displayName)")
 
-        if wasFirstClaudeAccount {
-            postAccountChanged(provider: .claude)
-        }
+        postAccountChanged(provider: .claude)
         return wasFirstClaudeAccount
     }
 
@@ -256,9 +257,8 @@ final class AccountStore: ObservableObject {
         // 如果删除的是当前账户，切换到第一个账户
         if wasCurrentAccount {
             currentAccountId = accounts.first?.id
-            // 发送账户变更通知
-            postAccountChanged(provider: .claude)
         }
+        postAccountChanged(provider: .claude)
 
         Logger.settings.notice("删除账户: \(account.displayName)")
     }
@@ -285,17 +285,34 @@ final class AccountStore: ObservableObject {
         accounts[index].alias = alias
         let displayName = accounts[index].displayName
         Logger.settings.notice("更新账户别名: \(displayName)")
+        postAccountChanged(provider: .claude)
     }
 
-    /// 静默更新当前 Claude 账户的 session-token（不触发 accountChanged 通知）
-    /// 用于 OAuth refresh_token 轮换场景——只更新持久化数据，不触发重新拉取循环
-    func silentlyUpdateCurrentClaudeSessionToken(_ token: String) {
-        guard let id = currentAccountId,
-              let index = accounts.firstIndex(where: { $0.id == id }) else { return }
+    /// Silently updates the specified Claude account session token without posting accountChanged.
+    /// OAuth rotation persists the new token without triggering another fetch cycle.
+    func silentlyUpdateClaudeSessionToken(
+        _ token: String,
+        for accountId: UUID,
+        replacing expectedToken: String? = nil
+    ) {
+        guard let index = accounts.firstIndex(where: { $0.id == accountId }) else { return }
+        guard expectedToken == nil || accounts[index].sessionKey == expectedToken else {
+            Logger.settings.info("忽略过期的 Claude token 轮换结果")
+            return
+        }
         guard accounts[index].sessionKey != token else { return }
-        // Account 是 struct，下标赋值触发 accounts.didSet → saveAccounts()，自动持久化
-        accounts[index].sessionKey = token
+        accounts = AccountCredentialUpdate.replacingCredential(
+            in: accounts,
+            accountId: accountId,
+            expectedToken: expectedToken,
+            token: token
+        )
         Logger.settings.notice("Claude session-token 已静默更新（自动续期）")
+    }
+
+    func silentlyUpdateCurrentClaudeSessionToken(_ token: String) {
+        guard let currentAccountId else { return }
+        silentlyUpdateClaudeSessionToken(token, for: currentAccountId)
     }
 
     // MARK: - Codex Account Management
@@ -303,7 +320,7 @@ final class AccountStore: ObservableObject {
     private func saveCodexAccounts() {
         // 在调用线程（主线程）快照，避免后台队列直接读取主线程持有的可变数组造成数据竞争
         let snapshot = codexAccounts
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        persistenceQueue.async { [weak self] in
             self?.keychain.saveCodexAccounts(snapshot)
         }
     }
@@ -326,6 +343,7 @@ final class AccountStore: ObservableObject {
             codexAccounts[index].sessionKey = account.sessionKey
             codexAccounts[index].organizationId = account.organizationId
             codexAccounts[index].organizationName = account.organizationName
+            codexAccounts[index].email = account.email
             codexAccounts[index].provider = .codex
             if currentCodexAccountId == nil {
                 currentCodexAccountId = codexAccounts[index].id
@@ -354,8 +372,8 @@ final class AccountStore: ObservableObject {
         NotificationManager.shared.resetNotificationStates(for: .codex, accountId: account.id)
         if wasCurrent {
             currentCodexAccountId = codexAccounts.first?.id
-            postAccountChanged(provider: .codex)
         }
+        postAccountChanged(provider: .codex)
         Logger.settings.notice("删除 Codex 账户: \(account.displayName)")
     }
 
@@ -371,17 +389,34 @@ final class AccountStore: ObservableObject {
         guard let index = codexAccounts.firstIndex(where: { $0.id == account.id }) else { return }
         codexAccounts[index].alias = alias
         Logger.settings.notice("更新 Codex 账户别名: \(self.codexAccounts[index].displayName)")
+        postAccountChanged(provider: .codex)
     }
 
-    /// 静默更新当前 Codex 账户的 session-token（不触发 accountChanged 通知）
-    /// 用于自动续期场景——只更新持久化数据，不触发重新拉取循环
-    func silentlyUpdateCurrentCodexSessionToken(_ token: String) {
-        guard let id = currentCodexAccountId,
-              let index = codexAccounts.firstIndex(where: { $0.id == id }) else { return }
+    /// Silently updates the specified Codex account session token without posting accountChanged.
+    /// Automatic renewal persists the new token without triggering another fetch cycle.
+    func silentlyUpdateCodexSessionToken(
+        _ token: String,
+        for accountId: UUID,
+        replacing expectedToken: String? = nil
+    ) {
+        guard let index = codexAccounts.firstIndex(where: { $0.id == accountId }) else { return }
+        guard expectedToken == nil || codexAccounts[index].sessionKey == expectedToken else {
+            Logger.settings.info("忽略过期的 Codex token 轮换结果")
+            return
+        }
         guard codexAccounts[index].sessionKey != token else { return }
-        // Account 是 struct，下标赋值触发 codexAccounts.didSet → saveCodexAccounts()，自动持久化
-        codexAccounts[index].sessionKey = token
+        codexAccounts = AccountCredentialUpdate.replacingCredential(
+            in: codexAccounts,
+            accountId: accountId,
+            expectedToken: expectedToken,
+            token: token
+        )
         Logger.settings.notice("Codex session-token 已静默更新（自动续期）")
+    }
+
+    func silentlyUpdateCurrentCodexSessionToken(_ token: String) {
+        guard let currentCodexAccountId else { return }
+        silentlyUpdateCodexSessionToken(token, for: currentCodexAccountId)
     }
 
     // MARK: - Shared Helpers

--- a/Usage4Claude/Models/AccountUsageSnapshot.swift
+++ b/Usage4Claude/Models/AccountUsageSnapshot.swift
@@ -1,0 +1,229 @@
+//
+//  AccountUsageSnapshot.swift
+//  Usage4Claude
+//
+//  Account-scoped usage state shared by refresh and menu-bar rendering.
+//
+
+import Foundation
+
+enum AccountUsagePayload: Sendable {
+    case claude(UsageData)
+    case codex(CodexUsageData)
+}
+
+struct AccountUsageSnapshot: Identifiable, Sendable {
+    let id: UUID
+    let provider: ProviderType
+    let displayName: String
+    let accountIdentity: String
+    let label: String
+    let payload: AccountUsagePayload?
+    let errorDescription: String?
+
+    init(
+        account: Account,
+        label: String? = nil,
+        payload: AccountUsagePayload? = nil,
+        errorDescription: String? = nil
+    ) {
+        id = account.id
+        provider = account.provider
+        displayName = account.displayName
+        accountIdentity = account.accountIdentity
+        self.label = label ?? account.displayName
+        self.payload = payload
+        self.errorDescription = errorDescription
+    }
+
+    init(
+        id: UUID,
+        provider: ProviderType,
+        displayName: String,
+        accountIdentity: String,
+        label: String,
+        payload: AccountUsagePayload?,
+        errorDescription: String?
+    ) {
+        self.id = id
+        self.provider = provider
+        self.displayName = displayName
+        self.accountIdentity = accountIdentity
+        self.label = label
+        self.payload = payload
+        self.errorDescription = errorDescription
+    }
+}
+
+enum AccountMenuBarPlan {
+    static func make(
+        claudeAccounts: [Account],
+        codexAccounts: [Account],
+        maxLabelLength: Int = 10
+    ) -> [AccountUsageSnapshot] {
+        let accounts = claudeAccounts + codexAccounts
+        let labelLength = max(1, maxLabelLength)
+        let baseLabels = accounts.map { account -> String in
+            let compact = String(account.displayName.prefix(labelLength))
+            return compact.isEmpty ? account.provider.displayName : compact
+        }
+        let counts = Dictionary(baseLabels.map { ($0, 1) }, uniquingKeysWith: +)
+        var occurrences: [String: Int] = [:]
+
+        return zip(accounts, baseLabels).map { account, baseLabel in
+            occurrences[baseLabel, default: 0] += 1
+            let label = counts[baseLabel, default: 0] > 1
+                ? "\(baseLabel) \(occurrences[baseLabel, default: 1])"
+                : baseLabel
+            return AccountUsageSnapshot(account: account, label: label)
+        }
+    }
+}
+
+enum AccountCredentialUpdate {
+    static func replacingCredential(
+        in accounts: [Account],
+        accountId: UUID,
+        expectedToken: String? = nil,
+        token: String
+    ) -> [Account] {
+        accounts.map { account in
+            guard account.id == accountId,
+                  expectedToken == nil || account.sessionKey == expectedToken else { return account }
+            return Account(
+                id: account.id,
+                sessionKey: token,
+                organizationId: account.organizationId,
+                organizationName: account.organizationName,
+                email: account.email,
+                alias: account.alias,
+                createdAt: account.createdAt,
+                provider: account.provider
+            )
+        }
+    }
+}
+
+enum AccountUsageResult: Sendable {
+    case success(AccountUsagePayload)
+    case failure(String)
+}
+
+enum AccountUsageReducer {
+    static func applying(
+        _ results: [UUID: Result<AccountUsagePayload, Error>],
+        to previous: [AccountUsageSnapshot],
+        plan: [AccountUsageSnapshot]
+    ) -> [AccountUsageSnapshot] {
+        let normalized = results.mapValues { result in
+            switch result {
+            case .success(let payload):
+                return AccountUsageResult.success(payload)
+            case .failure(let error):
+                return AccountUsageResult.failure(error.localizedDescription)
+            }
+        }
+        return merge(plan: plan, previous: previous, results: normalized)
+    }
+
+    static func merge(
+        plan: [AccountUsageSnapshot],
+        previous: [AccountUsageSnapshot],
+        results: [UUID: AccountUsageResult]
+    ) -> [AccountUsageSnapshot] {
+        let previousById = Dictionary(uniqueKeysWithValues: previous.map { ($0.id, $0) })
+
+        return plan.map { planned in
+            let old = previousById[planned.id]
+            let payload: AccountUsagePayload?
+            let errorDescription: String?
+
+            switch results[planned.id] {
+            case .success(let freshPayload):
+                payload = freshPayload
+                errorDescription = nil
+            case .failure(let error):
+                payload = old?.payload
+                errorDescription = error
+            case .none:
+                payload = old?.payload
+                errorDescription = old?.errorDescription
+            }
+
+            return AccountUsageSnapshot(
+                id: planned.id,
+                provider: planned.provider,
+                displayName: planned.displayName,
+                accountIdentity: planned.accountIdentity,
+                label: planned.label,
+                payload: payload,
+                errorDescription: errorDescription
+            )
+        }
+    }
+}
+
+enum AccountMenuBarSignature {
+    static func make(snapshots: [AccountUsageSnapshot], hasUpdate: Bool) -> String {
+        let accountParts = snapshots.map { snapshot in
+            [
+                snapshot.id.uuidString,
+                snapshot.provider.rawValue,
+                snapshot.label,
+                payloadSignature(snapshot.payload),
+                snapshot.errorDescription ?? ""
+            ].map { value in
+                "\(value.utf8.count)#\(value)"
+            }.joined(separator: ":")
+        }
+        return ([hasUpdate ? "badge" : "plain"] + accountParts).joined(separator: "|")
+    }
+
+    private static func payloadSignature(_ payload: AccountUsagePayload?) -> String {
+        guard let payload else { return "none" }
+        switch payload {
+        case .claude(let usage):
+            let weekly = usage.weeklyModels.map {
+                "\($0.modelName ?? "")=\($0.limit.percentage)"
+            }.joined(separator: ",")
+            let parts: [String] = [
+                "claude",
+                usage.fiveHour.map { String($0.percentage) } ?? "nil",
+                usage.sevenDay.map { String($0.percentage) } ?? "nil",
+                weekly,
+                usage.extraUsage?.enabled == true ? "1" : "0",
+                usage.extraUsage?.percentage.map { String($0) } ?? "nil"
+            ]
+            return parts.joined(separator: ";")
+        case .codex(let usage):
+            let parts: [String] = [
+                "codex",
+                usage.primary.map { String($0.percentage) } ?? "nil",
+                usage.secondary.map { String($0.percentage) } ?? "nil",
+                usage.extraUsage?.enabled == true ? "1" : "0",
+                usage.extraUsage?.percentage.map { String($0) } ?? "nil"
+            ]
+            return parts.joined(separator: ";")
+        }
+    }
+}
+
+extension Array where Element == AccountUsageSnapshot {
+    func selectedClaude(accountId: UUID?) -> UsageData? {
+        guard let accountId,
+              let snapshot = first(where: { $0.id == accountId }),
+              case .claude(let usage) = snapshot.payload else {
+            return nil
+        }
+        return usage
+    }
+
+    func selectedCodex(accountId: UUID?) -> CodexUsageData? {
+        guard let accountId,
+              let snapshot = first(where: { $0.id == accountId }),
+              case .codex(let usage) = snapshot.payload else {
+            return nil
+        }
+        return usage
+    }
+}

--- a/Usage4Claude/Models/AccountUsageSnapshot.swift
+++ b/Usage4Claude/Models/AccountUsageSnapshot.swift
@@ -7,6 +7,17 @@
 
 import Foundation
 
+enum AccountRequestGuard {
+    static func isCurrent(
+        accountId: UUID,
+        generation: Int,
+        currentAccountId: UUID?,
+        currentGeneration: Int
+    ) -> Bool {
+        accountId == currentAccountId && generation == currentGeneration
+    }
+}
+
 enum AccountUsagePayload: Sendable {
     case claude(UsageData)
     case codex(CodexUsageData)

--- a/Usage4Claude/Models/MenuBarAccountVisibility.swift
+++ b/Usage4Claude/Models/MenuBarAccountVisibility.swift
@@ -1,0 +1,38 @@
+//
+//  MenuBarAccountVisibility.swift
+//  Usage4Claude
+//
+
+import Foundation
+
+/// Value type backing the per-account menu bar visibility preference.
+///
+/// The persisted representation contains hidden accounts rather than visible
+/// accounts, so accounts added after the preference was saved remain visible.
+struct MenuBarAccountVisibility {
+    private(set) var hiddenAccountIds: Set<UUID>
+
+    init(persistedAccountIdStrings: [String]?) {
+        hiddenAccountIds = Set((persistedAccountIdStrings ?? []).compactMap(UUID.init(uuidString:)))
+    }
+
+    func isVisible(accountId: UUID) -> Bool {
+        !hiddenAccountIds.contains(accountId)
+    }
+
+    mutating func setVisibility(accountId: UUID, isVisible: Bool) {
+        if isVisible {
+            hiddenAccountIds.remove(accountId)
+        } else {
+            hiddenAccountIds.insert(accountId)
+        }
+    }
+
+    mutating func removeAccount(_ accountId: UUID) {
+        hiddenAccountIds.remove(accountId)
+    }
+
+    var persistedAccountIdStrings: [String] {
+        hiddenAccountIds.map(\.uuidString).sorted()
+    }
+}

--- a/Usage4Claude/Models/UserSettings.swift
+++ b/Usage4Claude/Models/UserSettings.swift
@@ -475,6 +475,17 @@ class UserSettings: ObservableObject {
         }
     }
 
+    /// Account IDs hidden from the menu bar. Accounts absent from this set are visible by default.
+    @Published private(set) var hiddenMenuBarAccountIds: Set<UUID> {
+        didSet {
+            defaults.set(
+                hiddenMenuBarAccountIds.map(\.uuidString).sorted(),
+                forKey: "hiddenMenuBarAccountIds"
+            )
+            NotificationCenter.default.post(name: .settingsChanged, object: nil)
+        }
+    }
+
     /// Popover 端是否应该显示自定义模式的占位符（0% 空壳）
     /// 仅当显示模式为 custom 且未开启"仅应用于菜单栏"时为 true
     var shouldShowCustomPlaceholderInPopover: Bool {
@@ -777,6 +788,11 @@ class UserSettings: ObservableObject {
         // 加载"自定义显示仅应用于菜单栏"开关，默认关闭（保持向后兼容）
         self.customDisplayMenuBarOnly = defaults.bool(forKey: "customDisplayMenuBarOnly")
 
+        let menuBarVisibility = MenuBarAccountVisibility(
+            persistedAccountIdStrings: defaults.array(forKey: "hiddenMenuBarAccountIds") as? [String]
+        )
+        self.hiddenMenuBarAccountIds = menuBarVisibility.hiddenAccountIds
+
         // 检查是否首次启动（如果没有保存过认证信息，就是首次启动）
         if !defaults.bool(forKey: "hasLaunched") {
             self.isFirstLaunch = true
@@ -833,6 +849,20 @@ class UserSettings: ObservableObject {
     /// 当前应用使用的 Locale（基于用户选择的语言）
     var appLocale: Locale {
         return language.locale
+    }
+
+    /// Returns whether an account should appear in the menu bar.
+    func isAccountVisibleInMenuBar(id: UUID) -> Bool {
+        !hiddenMenuBarAccountIds.contains(id)
+    }
+
+    /// Updates one account's menu-bar visibility and immediately notifies observers.
+    func setMenuBarVisibility(accountId: UUID, isVisible: Bool) {
+        var visibility = MenuBarAccountVisibility(
+            persistedAccountIdStrings: hiddenMenuBarAccountIds.map(\.uuidString)
+        )
+        visibility.setVisibility(accountId: accountId, isVisible: isVisible)
+        hiddenMenuBarAccountIds = visibility.hiddenAccountIds
     }
 
     /// 检查认证信息是否已配置
@@ -970,6 +1000,7 @@ class UserSettings: ObservableObject {
     /// - Parameter account: 要删除的账户
     func removeAccount(_ account: Account) {
         accountStore.removeAccount(account)
+        removeMenuBarVisibility(for: account.id)
     }
 
     /// 切换到指定账户
@@ -1005,6 +1036,7 @@ class UserSettings: ObservableObject {
 
     func removeCodexAccount(_ account: Account) {
         accountStore.removeCodexAccount(account)
+        removeMenuBarVisibility(for: account.id)
     }
 
     func switchToCodexAccount(_ account: Account) {
@@ -1015,16 +1047,40 @@ class UserSettings: ObservableObject {
         accountStore.updateCodexAccount(account, alias: alias)
     }
 
+    private func removeMenuBarVisibility(for accountId: UUID) {
+        var visibility = MenuBarAccountVisibility(
+            persistedAccountIdStrings: hiddenMenuBarAccountIds.map(\.uuidString)
+        )
+        visibility.removeAccount(accountId)
+        hiddenMenuBarAccountIds = visibility.hiddenAccountIds
+    }
+
     /// 静默更新当前 Codex 账户的 session-token（不触发 accountChanged 通知）
     /// 用于自动续期场景——只更新持久化数据，不触发重新拉取循环
     func silentlyUpdateCurrentCodexSessionToken(_ token: String) {
         accountStore.silentlyUpdateCurrentCodexSessionToken(token)
     }
 
+    func silentlyUpdateCodexSessionToken(
+        _ token: String,
+        for accountId: UUID,
+        replacing expectedToken: String? = nil
+    ) {
+        accountStore.silentlyUpdateCodexSessionToken(token, for: accountId, replacing: expectedToken)
+    }
+
     /// 静默更新当前 Claude 账户的 session-token（不触发 accountChanged 通知）
     /// 用于 OAuth refresh_token 轮换场景——只更新持久化数据，不触发重新拉取循环
     func silentlyUpdateCurrentClaudeSessionToken(_ token: String) {
         accountStore.silentlyUpdateCurrentClaudeSessionToken(token)
+    }
+
+    func silentlyUpdateClaudeSessionToken(
+        _ token: String,
+        for accountId: UUID,
+        replacing expectedToken: String? = nil
+    ) {
+        accountStore.silentlyUpdateClaudeSessionToken(token, for: accountId, replacing: expectedToken)
     }
 
     private func ensureDefaultCodexDisplayTypesForCustomMode() {

--- a/Usage4Claude/Resources/de.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/de.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "settings.general.menubar_hint" = "Legt fest, was in der Menüleiste angezeigt wird";
 "settings.general.menubar_theme" = "Menüleisten-Theme";
 "settings.general.display_content" = "Angezeigter Inhalt";
+"settings.general.menu_bar_accounts" = "Menüleisten-Konten";
+"settings.general.menu_bar_accounts_hint" = "Wählen Sie die Konten aus, die in der Menüleiste angezeigt werden.";
 "settings.general.monochrome_no_icon_hint" = "Die Symbolanzeige wird im einfarbigen Theme nicht unterstützt";
 "settings.general.refresh_section" = "Aktualisierungseinstellungen";
 "settings.general.refresh_mode" = "Aktualisierungsmodus";

--- a/Usage4Claude/Resources/en.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/en.lproj/Localizable.strings
@@ -436,3 +436,6 @@
 "weblogin.claude_oauth_manual_prompt" = "Paste the link from your browser's address bar (starts with http://localhost)";
 "weblogin.claude_oauth_manual_submit" = "Sign in with this link";
 "weblogin.claude_oauth_manual_invalid" = "No authorization code found. Copy the full link from your browser's address bar and try again.";
+
+"settings.general.menu_bar_accounts" = "Menu Bar Accounts";
+"settings.general.menu_bar_accounts_hint" = "Choose which accounts appear in the menu bar.";

--- a/Usage4Claude/Resources/fr.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/fr.lproj/Localizable.strings
@@ -55,6 +55,8 @@
 "settings.general.menubar_hint" = "Choisir ce qui s'affiche dans la barre des menus";
 "settings.general.menubar_theme" = "Thème de la barre des menus";
 "settings.general.display_content" = "Contenu affiché";
+"settings.general.menu_bar_accounts" = "Comptes de la barre des menus";
+"settings.general.menu_bar_accounts_hint" = "Choisissez les comptes affichés dans la barre des menus.";
 "settings.general.monochrome_no_icon_hint" = "L'affichage de l'icône n'est pas disponible avec le thème monochrome";
 "settings.general.refresh_section" = "Réglages d'actualisation";
 "settings.general.refresh_mode" = "Mode d'actualisation";

--- a/Usage4Claude/Resources/ja.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ja.lproj/Localizable.strings
@@ -55,6 +55,8 @@
 "settings.general.menubar_hint" = "メニューバーに表示する内容を選択";
 "settings.general.menubar_theme" = "メニューバーテーマ";
 "settings.general.display_content" = "表示内容";
+"settings.general.menu_bar_accounts" = "メニューバーのアカウント";
+"settings.general.menu_bar_accounts_hint" = "メニューバーに表示するアカウントを選択します。";
 "settings.general.monochrome_no_icon_hint" = "モノクロームテーマではアイコン表示に対応していません";
 "settings.general.refresh_section" = "更新設定";
 "settings.general.refresh_mode" = "更新モード";

--- a/Usage4Claude/Resources/ko.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/ko.lproj/Localizable.strings
@@ -55,6 +55,8 @@
 "settings.general.menubar_hint" = "메뉴바에 표시할 내용 선택";
 "settings.general.menubar_theme" = "메뉴바 테마";
 "settings.general.display_content" = "표시 내용";
+"settings.general.menu_bar_accounts" = "메뉴 막대 계정";
+"settings.general.menu_bar_accounts_hint" = "메뉴 막대에 표시할 계정을 선택하세요.";
 "settings.general.monochrome_no_icon_hint" = "단색 테마에서는 아이콘 표시를 지원하지 않습니다";
 "settings.general.refresh_section" = "새로고침 설정";
 "settings.general.refresh_mode" = "새로고침 모드";

--- a/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hans.lproj/Localizable.strings
@@ -55,6 +55,8 @@
 "settings.general.menubar_hint" = "选择菜单栏中显示的内容";
 "settings.general.menubar_theme" = "菜单栏主题";
 "settings.general.display_content" = "显示内容";
+"settings.general.menu_bar_accounts" = "菜单栏账户";
+"settings.general.menu_bar_accounts_hint" = "选择要在菜单栏中显示的账户。";
 "settings.general.monochrome_no_icon_hint" = "单色主题下不支持显示图标";
 "settings.general.refresh_section" = "刷新设置";
 "settings.general.refresh_mode" = "刷新模式";

--- a/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Usage4Claude/Resources/zh-Hant.lproj/Localizable.strings
@@ -55,6 +55,8 @@
 "settings.general.menubar_hint" = "選擇選單列中顯示的內容";
 "settings.general.menubar_theme" = "選單列主題";
 "settings.general.display_content" = "顯示內容";
+"settings.general.menu_bar_accounts" = "選單列帳戶";
+"settings.general.menu_bar_accounts_hint" = "選擇要在選單列中顯示的帳戶。";
 "settings.general.monochrome_no_icon_hint" = "單色主題下不支援顯示圖示";
 "settings.general.refresh_section" = "重新整理設定";
 "settings.general.refresh_mode" = "重新整理模式";

--- a/Usage4Claude/Services/ClaudeAPIService.swift
+++ b/Usage4Claude/Services/ClaudeAPIService.swift
@@ -76,6 +76,16 @@ class ClaudeAPIService {
     /// - Important: 调用前确保用户已配置有效的认证信息
     /// - Note: 同时并行调用主 usage API 和 Extra Usage API，Extra Usage 失败不影响主功能
     func fetchUsage(completion: @escaping (Result<UsageData, Error>) -> Void) {
+        guard let account = settings.currentAccount else {
+            DispatchQueue.main.async { completion(.failure(UsageError.noCredentials)) }
+            return
+        }
+        fetchUsage(for: account, completion: completion)
+    }
+
+    /// Fetches usage for one Claude account. The account snapshot remains attached to the
+    /// request and token-rotation flow instead of consulting mutable global selection state.
+    func fetchUsage(for account: Account, completion: @escaping (Result<UsageData, Error>) -> Void) {
         #if DEBUG
         // 调试模式：返回模拟数据（立即返回，无延迟）
         if settings.debugModeEnabled {
@@ -91,14 +101,19 @@ class ClaudeAPIService {
         currentTask?.cancel()
 
         // 检查认证信息
-        guard settings.hasValidCredentials else {
+        guard !account.sessionKey.isEmpty else {
             DispatchQueue.main.async { completion(.failure(UsageError.noCredentials)) }
             return
         }
 
         // OAuth 账户：凭据是 refresh_token，走 /api/oauth/usage 路径，跳过 Cloudflare cookie 流程
-        if Self.isOAuthRefreshToken(settings.sessionKey) {
-            fetchOAuthUsage(completion: completion)
+        if Self.isOAuthRefreshToken(account.sessionKey) {
+            fetchOAuthUsage(for: account, completion: completion)
+            return
+        }
+
+        guard !account.organizationId.isEmpty else {
+            DispatchQueue.main.async { completion(.failure(UsageError.noCredentials)) }
             return
         }
 
@@ -110,7 +125,7 @@ class ClaudeAPIService {
 
         // ========== 请求1: 主 Usage API ==========
         dispatchGroup.enter()
-        fetchMainUsage { result in
+        fetchMainUsage(for: account) { result in
             switch result {
             case .success(let data):
                 mainUsageData = data
@@ -122,7 +137,7 @@ class ClaudeAPIService {
 
         // ========== 请求2: Extra Usage API（可选） ==========
         dispatchGroup.enter()
-        fetchExtraUsage { result in
+        fetchExtraUsage(for: account) { result in
             switch result {
             case .success(let data):
                 extraUsageData = data  // 可能为 nil（功能未启用或失败）
@@ -161,13 +176,13 @@ class ClaudeAPIService {
 
     /// 获取主 Usage API 数据（内部方法）
     /// - Parameter completion: 完成回调
-    private func fetchMainUsage(completion: @escaping (Result<UsageData, Error>) -> Void) {
+    private func fetchMainUsage(for account: Account, completion: @escaping (Result<UsageData, Error>) -> Void) {
         // Service 层统一约定：所有 completion 一律在主线程回调，调用方无需再包一层 DispatchQueue.main.async
         let complete: (Result<UsageData, Error>) -> Void = { result in
             DispatchQueue.main.async { completion(result) }
         }
 
-        let urlString = "\(baseURL)/\(settings.organizationId)/usage"
+        let urlString = "\(baseURL)/\(account.organizationId)/usage"
 
         guard let url = URL(string: urlString) else {
             complete(.failure(UsageError.invalidURL))
@@ -181,8 +196,8 @@ class ClaudeAPIService {
         // 使用统一的 Header 构建器添加完整的浏览器 Headers 以绕过 Cloudflare
         ClaudeAPIHeaderBuilder.applyHeaders(
             to: &request,
-            organizationId: settings.organizationId,
-            sessionKey: settings.sessionKey
+            organizationId: account.organizationId,
+            sessionKey: account.sessionKey
         )
 
         // 创建并保存任务引用
@@ -361,18 +376,26 @@ class ClaudeAPIService {
     /// - Parameter completion: 完成回调，包含成功的 ExtraUsageData 或失败的 Error
     /// - Note: 此方法是可选的，即使失败也不应影响主要功能
     func fetchExtraUsage(completion: @escaping (Result<ExtraUsageData?, Error>) -> Void) {
+        guard let account = settings.currentAccount else {
+            DispatchQueue.main.async { completion(.failure(UsageError.noCredentials)) }
+            return
+        }
+        fetchExtraUsage(for: account, completion: completion)
+    }
+
+    private func fetchExtraUsage(for account: Account, completion: @escaping (Result<ExtraUsageData?, Error>) -> Void) {
         // Service 层统一约定：所有 completion 一律在主线程回调，调用方无需再包一层 DispatchQueue.main.async
         let complete: (Result<ExtraUsageData?, Error>) -> Void = { result in
             DispatchQueue.main.async { completion(result) }
         }
 
         // 检查认证信息
-        guard settings.hasValidCredentials else {
+        guard !account.sessionKey.isEmpty, !account.organizationId.isEmpty else {
             complete(.failure(UsageError.noCredentials))
             return
         }
 
-        let urlString = "\(baseURL)/\(settings.organizationId)/overage_spend_limit"
+        let urlString = "\(baseURL)/\(account.organizationId)/overage_spend_limit"
 
         guard let url = URL(string: urlString) else {
             complete(.failure(UsageError.invalidURL))
@@ -386,8 +409,8 @@ class ClaudeAPIService {
         // 使用统一的 Header 构建器添加完整的浏览器 Headers
         ClaudeAPIHeaderBuilder.applyHeaders(
             to: &request,
-            organizationId: settings.organizationId,
-            sessionKey: settings.sessionKey
+            organizationId: account.organizationId,
+            sessionKey: account.sessionKey
         )
 
         let task = session.dataTask(with: request) { data, response, error in
@@ -451,26 +474,31 @@ class ClaudeAPIService {
     /// - Parameter retryOnUnauthorized: 收到 401 时是否清缓存后立即重试一次（强制换新 access_token）。
     ///   仿照 Codex 侧 `DataRefreshManager.fetchCodexOnly(retryOnUnauthorized:)` 的既有模式，
     ///   避免用户在下一个刷新周期到来前一直看到错误状态。
-    private func fetchOAuthUsage(retryOnUnauthorized: Bool = true, completion: @escaping (Result<UsageData, Error>) -> Void) {
-        let refreshToken = settings.sessionKey
-        fetchOAuthAccessToken(refreshToken: refreshToken) { [weak self] result in
+    private func fetchOAuthUsage(for account: Account, retryOnUnauthorized: Bool = true, completion: @escaping (Result<UsageData, Error>) -> Void) {
+        let refreshToken = account.sessionKey
+        fetchOAuthAccessToken(refreshToken: refreshToken, accountId: account.id) { [weak self] result in
             guard let self else { return }
             switch result {
             case .failure(let error):
                 DispatchQueue.main.async { completion(.failure(error)) }
             case .success(let accessToken):
-                self.fetchClaudeOAuthUsageData(accessToken: accessToken, retryOnUnauthorized: retryOnUnauthorized, completion: completion)
+                self.fetchClaudeOAuthUsageData(
+                    accessToken: accessToken,
+                    account: account,
+                    retryOnUnauthorized: retryOnUnauthorized,
+                    completion: completion
+                )
             }
         }
     }
 
     /// 用 refresh_token 获取 access_token，带缓存 + 单飞合并（委托给 OAuthTokenCache actor）
-    private func fetchOAuthAccessToken(refreshToken: String, completion: @escaping (Result<String, Error>) -> Void) {
+    private func fetchOAuthAccessToken(refreshToken: String, accountId: UUID, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 let accessToken = try await oauthTokenCache.accessToken(refreshToken: refreshToken) { [weak self] token in
                     guard let self else { throw UsageError.decodingError }
-                    return try await self.refreshClaudeOAuthTokens(refreshToken: token)
+                    return try await self.refreshClaudeOAuthTokens(refreshToken: token, accountId: accountId)
                 }
                 await MainActor.run { completion(.success(accessToken)) }
             } catch {
@@ -481,7 +509,7 @@ class ClaudeAPIService {
 
     /// 实际发起网络请求向 Claude OAuth 端点换取新 token；处理 refresh_token 轮换的静默写回。
     /// 只会在 OAuthTokenCache 判定"确实需要发起新刷新"时才被调用一次（并发调用者共享同一次结果）。
-    private func refreshClaudeOAuthTokens(refreshToken: String) async throws -> OAuthTokenCache.Tokens {
+    private func refreshClaudeOAuthTokens(refreshToken: String, accountId: UUID) async throws -> OAuthTokenCache.Tokens {
         do {
             let tokens = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ClaudeOAuthTokens, Error>) in
                 ClaudeOAuthService.refresh(refreshToken: refreshToken) { result in
@@ -494,7 +522,11 @@ class ClaudeAPIService {
             if newRefresh != refreshToken {
                 Logger.api.notice("Claude OAuth: refresh_token 已轮换，静默写回")
                 await MainActor.run {
-                    UserSettings.shared.silentlyUpdateCurrentClaudeSessionToken(newRefresh)
+                    UserSettings.shared.silentlyUpdateClaudeSessionToken(
+                        newRefresh,
+                        for: accountId,
+                        replacing: refreshToken
+                    )
                 }
             }
 
@@ -508,7 +540,12 @@ class ClaudeAPIService {
     }
 
     /// 用 access_token 调用 /api/oauth/usage，解析为 UsageData
-    private func fetchClaudeOAuthUsageData(accessToken: String, retryOnUnauthorized: Bool, completion: @escaping (Result<UsageData, Error>) -> Void) {
+    private func fetchClaudeOAuthUsageData(
+        accessToken: String,
+        account: Account,
+        retryOnUnauthorized: Bool,
+        completion: @escaping (Result<UsageData, Error>) -> Void
+    ) {
         // Service 层统一约定：所有 completion 一律在主线程回调，调用方无需再包一层 DispatchQueue.main.async
         let complete: (Result<UsageData, Error>) -> Void = { result in
             DispatchQueue.main.async { completion(result) }
@@ -544,9 +581,11 @@ class ClaudeAPIService {
                     // （二者都要进 actor，若各开一个 Task 无法保证 clear 先于重试执行）。
                     if retryOnUnauthorized {
                         Logger.api.info("Claude OAuth usage 401，清缓存后立即用 refresh_token 换新 access_token 重试一次")
-                        Task {
-                            await self?.oauthTokenCache.clear()
-                            self?.fetchOAuthUsage(retryOnUnauthorized: false, completion: completion)
+                        Task { @MainActor [weak self] in
+                            guard let self else { return }
+                            await self.oauthTokenCache.clear()
+                            let latestAccount = self.settings.accounts.first { $0.id == account.id } ?? account
+                            self.fetchOAuthUsage(for: latestAccount, retryOnUnauthorized: false, completion: completion)
                         }
                     } else {
                         Task { await self?.oauthTokenCache.clear() }
@@ -624,6 +663,12 @@ class ClaudeAPIService {
     func fetchUsageResult() async -> Result<UsageData, Error> {
         await withCheckedContinuation { continuation in
             fetchUsage { continuation.resume(returning: $0) }
+        }
+    }
+
+    func fetchUsageResult(for account: Account) async -> Result<UsageData, Error> {
+        await withCheckedContinuation { continuation in
+            fetchUsage(for: account) { continuation.resume(returning: $0) }
         }
     }
 

--- a/Usage4Claude/Services/CodexAPIService.swift
+++ b/Usage4Claude/Services/CodexAPIService.swift
@@ -58,8 +58,9 @@ class CodexAPIService {
     /// 由独立计时器调用：仅在缓存即将过期时主动续期，不触发用量拉取。
     /// fetchAccessToken 内部先查缓存（20 分钟余量），缓存仍新鲜时不会发起网络请求。
     func proactivelyRefreshIfNeeded() {
-        guard settings.hasValidCodexCredentials else { return }
-        fetchAccessToken(sessionToken: settings.codexSessionToken) { result in
+        guard let account = settings.currentCodexAccount,
+              !account.sessionKey.isEmpty else { return }
+        fetchAccessToken(sessionToken: account.sessionKey, accountId: account.id) { result in
             switch result {
             case .success:
                 Logger.api.debug("Codex accessToken: 主动续期检查完成")
@@ -86,6 +87,16 @@ class CodexAPIService {
     /// 获取 Codex 用量（两步：session → usage）
     /// - Parameter completion: 成功返回 CodexUsageData，失败返回 Error
     func fetchUsage(completion: @escaping (Result<CodexUsageData, Error>) -> Void) {
+        guard let account = settings.currentCodexAccount else {
+            DispatchQueue.main.async { completion(.failure(UsageError.noCredentials)) }
+            return
+        }
+        fetchUsage(for: account, completion: completion)
+    }
+
+    /// Fetches usage for one Codex account. The account UUID follows token renewal so a
+    /// rotated refresh token cannot be written to whichever account is selected later.
+    func fetchUsage(for account: Account, completion: @escaping (Result<CodexUsageData, Error>) -> Void) {
         #if DEBUG
         if settings.debugModeEnabled {
             let mockData = createMockData()
@@ -96,15 +107,15 @@ class CodexAPIService {
 
         cancelAllRequests()
 
-        guard settings.hasValidCodexCredentials else {
-            completion(.failure(UsageError.noCredentials))
+        guard !account.sessionKey.isEmpty else {
+            DispatchQueue.main.async { completion(.failure(UsageError.noCredentials)) }
             return
         }
 
-        let sessionToken = settings.codexSessionToken
+        let sessionToken = account.sessionKey
 
         // fetchAccessToken 的 completion 已保证主线程回调
-        fetchAccessToken(sessionToken: sessionToken) { [weak self] result in
+        fetchAccessToken(sessionToken: sessionToken, accountId: account.id) { [weak self] result in
             guard let self = self else { return }
 
             switch result {
@@ -133,7 +144,11 @@ class CodexAPIService {
     ///
     /// 缓存有效时（距过期 > 20 分钟）跳过网络请求；同一凭据的并发调用由
     /// OAuthTokenCache 合并为一次网络请求。completion 一律主线程回调。
-    private func fetchAccessToken(sessionToken: String, completion: @escaping (Result<String, Error>) -> Void) {
+    private func fetchAccessToken(
+        sessionToken: String,
+        accountId: UUID,
+        completion: @escaping (Result<String, Error>) -> Void
+    ) {
         Task {
             do {
                 let accessToken = try await tokenCache.accessToken(
@@ -142,9 +157,9 @@ class CodexAPIService {
                 ) { [weak self] credential in
                     guard let self else { throw UsageError.networkError }
                     if Self.isOAuthRefreshToken(credential) {
-                        return try await self.refreshOAuthTokens(refreshToken: credential)
+                        return try await self.refreshOAuthTokens(refreshToken: credential, accountId: accountId)
                     }
-                    return try await self.fetchSessionTokens(sessionToken: credential)
+                    return try await self.fetchSessionTokens(sessionToken: credential, accountId: accountId)
                 }
                 await MainActor.run { completion(.success(accessToken)) }
             } catch {
@@ -169,7 +184,7 @@ class CodexAPIService {
     /// cookie 账户：调用 /api/auth/session 换取 accessToken，返回统一的 Tokens 三元组。
     /// 若响应通过 Set-Cookie 轮换了 session-token，静默写回账户存储，并把新值作为
     /// 返回的 refreshToken——缓存键跟随新凭据，下次用新 session-token 查询可直接命中。
-    private func fetchSessionTokens(sessionToken: String) async throws -> OAuthTokenCache.Tokens {
+    private func fetchSessionTokens(sessionToken: String, accountId: UUID) async throws -> OAuthTokenCache.Tokens {
         guard let url = URL(string: "\(baseURL)/api/auth/session") else {
             throw UsageError.invalidURL
         }
@@ -194,12 +209,17 @@ class CodexAPIService {
                         return .failure(UsageError.cloudflareBlocked)
                     }
 
+                    let setCookieHeaders: [String] = if let httpResponse = response as? HTTPURLResponse {
+                        httpResponse.allHeaderFields
+                            .filter { ($0.key as? String)?.lowercased() == "set-cookie" }
+                            .compactMap { $0.value as? String }
+                    } else {
+                        []
+                    }
+
                     if let httpResponse = response as? HTTPURLResponse {
                         Logger.api.debug("Codex session HTTP status: \(httpResponse.statusCode)")
                         // Phase 0 诊断：检查 /api/auth/session 是否下发新 session-token
-                        let setCookieHeaders = httpResponse.allHeaderFields
-                            .filter { ($0.key as? String)?.lowercased() == "set-cookie" }
-                            .compactMap { $0.value as? String }
                         Logger.api.debug("Codex session Set-Cookie 数量=\(setCookieHeaders.count)")
                         for cookieStr in setCookieHeaders where cookieStr.contains("next-auth.session-token") {
                             Logger.api.info("Codex session Set-Cookie [SESSION-TOKEN] \(cookieStr.prefix(80))")
@@ -215,17 +235,25 @@ class CodexAPIService {
                         }
                     }
 
-                    // 检查 HTTPCookieStorage 是否收到轮换后的新 session-token
-                    // （用已捕获的 sessionToken 参数比较，避免在后台线程读取 @Published 属性）
+                    // Inspect only this response's Set-Cookie values. Reading shared cookie
+                    // storage could pick up another account's concurrently rotated token.
                     var effectiveSessionToken = sessionToken
-                    let chatgptURL = URL(string: "https://chatgpt.com")!
-                    let storedCookies = HTTPCookieStorage.shared.cookies(for: chatgptURL) ?? []
-                    if let newToken = CodexWebLoginCoordinator.extractSessionToken(from: storedCookies),
+                    let responseCookies = setCookieHeaders.flatMap { header in
+                        HTTPCookie.cookies(
+                            withResponseHeaderFields: ["Set-Cookie": header],
+                            for: request.url!
+                        )
+                    }
+                    if let newToken = CodexWebLoginCoordinator.extractSessionToken(from: responseCookies),
                        newToken != sessionToken {
                         Logger.api.notice("Codex session: 检测到新 session-token，静默写回")
                         effectiveSessionToken = newToken
                         DispatchQueue.main.async {
-                            UserSettings.shared.silentlyUpdateCurrentCodexSessionToken(newToken)
+                            UserSettings.shared.silentlyUpdateCodexSessionToken(
+                                newToken,
+                                for: accountId,
+                                replacing: sessionToken
+                            )
                         }
                     }
 
@@ -262,7 +290,7 @@ class CodexAPIService {
     /// OAuth 账户：用 refresh_token 向 auth.openai.com 换取 access_token。
     /// 只会在 OAuthTokenCache 判定「确实需要发起新刷新」时被调用一次（并发调用共享同一次结果）。
     /// refresh_token 轮换时静默写回账户存储，并作为返回的 refreshToken（缓存键跟随新值）。
-    private func refreshOAuthTokens(refreshToken: String) async throws -> OAuthTokenCache.Tokens {
+    private func refreshOAuthTokens(refreshToken: String, accountId: UUID) async throws -> OAuthTokenCache.Tokens {
         let tokens = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<CodexOAuthTokens, Error>) in
             CodexOAuthService.refresh(refreshToken: refreshToken) { result in
                 continuation.resume(with: result)
@@ -273,7 +301,11 @@ class CodexAPIService {
         if newRefresh != refreshToken {
             Logger.api.notice("Codex OAuth: refresh_token 已轮换，静默写回")
             await MainActor.run {
-                UserSettings.shared.silentlyUpdateCurrentCodexSessionToken(newRefresh)
+                UserSettings.shared.silentlyUpdateCodexSessionToken(
+                    newRefresh,
+                    for: accountId,
+                    replacing: refreshToken
+                )
             }
         }
 
@@ -298,6 +330,12 @@ class CodexAPIService {
     func fetchUsageResult() async -> Result<CodexUsageData, Error> {
         await withCheckedContinuation { continuation in
             fetchUsage { continuation.resume(returning: $0) }
+        }
+    }
+
+    func fetchUsageResult(for account: Account) async -> Result<CodexUsageData, Error> {
+        await withCheckedContinuation { continuation in
+            fetchUsage(for: account) { continuation.resume(returning: $0) }
         }
     }
 

--- a/Usage4Claude/Services/NotificationManager.swift
+++ b/Usage4Claude/Services/NotificationManager.swift
@@ -64,35 +64,39 @@ final class NotificationManager: NSObject {
     /// - Parameters:
     ///   - usageData: 最新的用量数据
     ///   - previousData: 上一次的用量数据（用于对比变化）
-    func checkAndNotify(usageData: UsageData, previousData: UsageData?) {
+    func checkAndNotify(accountId: UUID, usageData: UsageData, previousData: UsageData?) {
         // 逐个限制类型检查
         checkLimit(
             type: .fiveHour,
             current: usageData.fiveHour?.percentage,
             previous: previousData?.fiveHour?.percentage,
             currentResetsAt: usageData.fiveHour?.resetsAt,
-            previousResetsAt: previousData?.fiveHour?.resetsAt
+            previousResetsAt: previousData?.fiveHour?.resetsAt,
+            accountId: accountId
         )
         checkLimit(
             type: .sevenDay,
             current: usageData.sevenDay?.percentage,
             previous: previousData?.sevenDay?.percentage,
             currentResetsAt: usageData.sevenDay?.resetsAt,
-            previousResetsAt: previousData?.sevenDay?.resetsAt
+            previousResetsAt: previousData?.sevenDay?.resetsAt,
+            accountId: accountId
         )
         checkLimit(
             type: .opusWeekly,
             current: usageData.opus?.percentage,
             previous: previousData?.opus?.percentage,
             currentResetsAt: usageData.opus?.resetsAt,
-            previousResetsAt: previousData?.opus?.resetsAt
+            previousResetsAt: previousData?.opus?.resetsAt,
+            accountId: accountId
         )
         checkLimit(
             type: .sonnetWeekly,
             current: usageData.sonnet?.percentage,
             previous: previousData?.sonnet?.percentage,
             currentResetsAt: usageData.sonnet?.resetsAt,
-            previousResetsAt: previousData?.sonnet?.resetsAt
+            previousResetsAt: previousData?.sonnet?.resetsAt,
+            accountId: accountId
         )
 
         // Extra Usage 单独处理
@@ -101,7 +105,8 @@ final class NotificationManager: NSObject {
             current: usageData.extraUsage?.percentage,
             previous: previousData?.extraUsage?.percentage,
             currentResetsAt: nil,
-            previousResetsAt: nil
+            previousResetsAt: nil,
+            accountId: accountId
         )
     }
 
@@ -109,27 +114,30 @@ final class NotificationManager: NSObject {
     /// - Parameters:
     ///   - codexUsageData: 最新的 Codex 用量数据
     ///   - previousData: 上一次的 Codex 用量数据（用于对比变化）
-    func checkAndNotify(codexUsageData: CodexUsageData, previousData: CodexUsageData?) {
+    func checkAndNotify(accountId: UUID, codexUsageData: CodexUsageData, previousData: CodexUsageData?) {
         checkLimit(
             type: .codexPrimary,
             current: codexUsageData.primary?.percentage,
             previous: previousData?.primary?.percentage,
             currentResetsAt: codexUsageData.primary?.resetsAt,
-            previousResetsAt: previousData?.primary?.resetsAt
+            previousResetsAt: previousData?.primary?.resetsAt,
+            accountId: accountId
         )
         checkLimit(
             type: .codexSecondary,
             current: codexUsageData.secondary?.percentage,
             previous: previousData?.secondary?.percentage,
             currentResetsAt: codexUsageData.secondary?.resetsAt,
-            previousResetsAt: previousData?.secondary?.resetsAt
+            previousResetsAt: previousData?.secondary?.resetsAt,
+            accountId: accountId
         )
         checkLimit(
             type: .codexExtraUsage,
             current: codexUsageData.extraUsage?.percentage,
             previous: previousData?.extraUsage?.percentage,
             currentResetsAt: nil,
-            previousResetsAt: nil
+            previousResetsAt: nil,
+            accountId: accountId
         )
     }
 
@@ -143,12 +151,13 @@ final class NotificationManager: NSObject {
         current: Double?,
         previous: Double?,
         currentResetsAt: Date?,
-        previousResetsAt: Date?
+        previousResetsAt: Date?,
+        accountId: UUID
     ) {
-        let warningKey = notificationKey(for: type)
+        let warningKey = notificationKey(for: type, accountId: accountId)
         // 7天限制额外检查 75% 阈值，其余类型不做早期预警
         let earlyWarningKey = (type == .sevenDay || type == .codexSecondary)
-            ? notificationKey(for: type, suffix: "75")
+            ? notificationKey(for: type, accountId: accountId, suffix: "75")
             : nil
 
         let (actions, updatedWarnings) = NotificationDecisionEngine.evaluate(
@@ -176,14 +185,7 @@ final class NotificationManager: NSObject {
         }
     }
 
-    private func notificationKey(for type: LimitType, suffix: String? = nil) -> String {
-        let accountId: UUID?
-        switch type.provider {
-        case .claude:
-            accountId = UserSettings.shared.currentAccountId
-        case .codex:
-            accountId = UserSettings.shared.currentCodexAccountId
-        }
+    private func notificationKey(for type: LimitType, accountId: UUID, suffix: String? = nil) -> String {
         return Self.makeNotificationKey(
             provider: type.provider,
             accountId: accountId,

--- a/Usage4Claude/Views/Settings/Tabs/GeneralSettingsDisplaySection.swift
+++ b/Usage4Claude/Views/Settings/Tabs/GeneralSettingsDisplaySection.swift
@@ -101,7 +101,46 @@ struct GeneralSettingsDisplaySection: View {
                         .disabled(settings.iconDisplayMode == .percentageOnly)
                     }
                 }
+
+                if !settings.accounts.isEmpty || !settings.codexAccounts.isEmpty {
+                    Divider()
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(L.SettingsGeneral.menuBarAccounts)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundColor(.secondary)
+
+                        Text(L.SettingsGeneral.menuBarAccountsHint)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        ForEach(settings.accounts) { account in
+                            accountVisibilityToggle(account, provider: .claude)
+                        }
+
+                        ForEach(settings.codexAccounts) { account in
+                            accountVisibilityToggle(account, provider: .codex)
+                        }
+                    }
+                }
             }
         }
+    }
+
+    private func accountVisibilityToggle(_ account: Account, provider: ProviderType) -> some View {
+        Toggle(isOn: Binding(
+                        get: { settings.isAccountVisibleInMenuBar(id: account.id) },
+            set: { settings.setMenuBarVisibility(accountId: account.id, isVisible: $0) }
+        )) {
+            HStack(spacing: 6) {
+                Text(account.presentationLabel)
+                Text(provider.displayName)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .toggleStyle(.checkbox)
+        .focusable(false)
     }
 }

--- a/Usage4Claude/Views/UsageDetailView.swift
+++ b/Usage4Claude/Views/UsageDetailView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct UsageDetailView: View {
     @Binding var usageData: UsageData?
     @Binding var codexUsageData: CodexUsageData?
+    @Binding var accountUsageSnapshots: [AccountUsageSnapshot]
     @Binding var errorMessage: String?
     @Binding var codexErrorMessage: String?
     /// Codex 三级刷新均失败，需要用户手动重新登录
@@ -83,6 +84,15 @@ struct UsageDetailView: View {
     private var isMultiProviderActive: Bool {
         UserSettings.shared.isMultiProviderActive
             && (codexUsageData != nil || codexErrorMessage != nil || UserSettings.shared.hasValidCodexCredentials)
+    }
+
+    private var orderedAccountUsageSnapshots: [AccountUsageSnapshot] {
+        accountUsageSnapshots.filter { $0.provider == .claude }
+            + accountUsageSnapshots.filter { $0.provider == .codex }
+    }
+
+    private var showsAllAccounts: Bool {
+        !orderedAccountUsageSnapshots.isEmpty
     }
 
     private var isCodexOnlyActive: Bool {
@@ -177,10 +187,16 @@ struct UsageDetailView: View {
     }
 
     private var contentWidth: CGFloat {
-        isMultiProviderActive ? 580 : 290
+        if showsAllAccounts {
+            return 620
+        }
+        return isMultiProviderActive ? 580 : 290
     }
 
     private var contentHeight: CGFloat {
+        if showsAllAccounts {
+            return 560
+        }
         if isMultiProviderActive {
             return multiProviderHeight
         }
@@ -695,6 +711,31 @@ struct UsageDetailView: View {
         }
     }
 
+    private var allAccountsBody: some View {
+        VStack(spacing: 10) {
+            HStack {
+                Text(L.Menu.account)
+                    .font(.headline)
+                Spacer()
+                refreshAndMenuButtons
+            }
+            .padding(.horizontal)
+            .padding(.top)
+
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    ForEach(orderedAccountUsageSnapshots) { snapshot in
+                        AccountUsageSnapshotCard(snapshot: snapshot)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 4)
+            }
+
+            updateNotificationView
+        }
+    }
+
     private func multiProviderBody(codex: CodexUsageData?) -> some View {
         VStack(spacing: contentSpacing) {
             HStack(alignment: .top, spacing: 0) {
@@ -766,7 +807,9 @@ struct UsageDetailView: View {
 
     var body: some View {
         Group {
-            if isMultiProviderActive {
+            if showsAllAccounts {
+                allAccountsBody
+            } else if isMultiProviderActive {
                 multiProviderBody(codex: codexUsageData)
             } else if isCodexOnlyActive {
                 codexOnlyBody(codex: codexUsageData)
@@ -889,6 +932,7 @@ struct UsageDetailView_Previews: PreviewProvider {
         UsageDetailView(
             usageData: $sampleData,
             codexUsageData: $codexData,
+            accountUsageSnapshots: .constant([]),
             errorMessage: $errorMsg,
             codexErrorMessage: $codexErrorMsg,
             codexNeedsRelogin: $codexNeedsRelogin,
@@ -897,4 +941,111 @@ struct UsageDetailView_Previews: PreviewProvider {
             shouldShowUpdateBadge: $shouldShowBadge
         )
     }
+}
+
+private struct AccountUsageSnapshotCard: View {
+    let snapshot: AccountUsageSnapshot
+
+    private struct UsageRow: Identifiable {
+        let id: String
+        let name: String
+        let percentage: Double
+    }
+
+    private var usageRows: [UsageRow] {
+        switch snapshot.payload {
+        case .claude(let usage):
+            var rows: [UsageRow] = []
+            if let limit = usage.fiveHour {
+                rows.append(UsageRow(id: LimitType.fiveHour.rawValue, name: LimitType.fiveHour.displayName, percentage: limit.percentage))
+            }
+            if let limit = usage.sevenDay {
+                rows.append(UsageRow(id: LimitType.sevenDay.rawValue, name: LimitType.sevenDay.displayName, percentage: limit.percentage))
+            }
+            for (index, model) in usage.weeklyModels.enumerated() {
+                let fallbackName = index == 0 ? LimitType.opusWeekly.displayName : LimitType.sonnetWeekly.displayName
+                rows.append(UsageRow(id: "weekly-\(index)", name: model.modelName ?? fallbackName, percentage: model.limit.percentage))
+            }
+            if let percentage = usage.extraUsage?.percentage {
+                rows.append(UsageRow(id: LimitType.extraUsage.rawValue, name: LimitType.extraUsage.displayName, percentage: percentage))
+            }
+            return rows
+        case .codex(let usage):
+            var rows: [UsageRow] = []
+            if let limit = usage.primary {
+                rows.append(UsageRow(id: LimitType.codexPrimary.rawValue, name: LimitType.codexPrimary.displayName, percentage: limit.percentage))
+            }
+            if let limit = usage.secondary {
+                rows.append(UsageRow(id: LimitType.codexSecondary.rawValue, name: LimitType.codexSecondary.displayName, percentage: limit.percentage))
+            }
+            if let percentage = usage.extraUsage?.percentage {
+                rows.append(UsageRow(id: LimitType.codexExtraUsage.rawValue, name: LimitType.codexExtraUsage.displayName, percentage: percentage))
+            }
+            return rows
+        case nil:
+            return []
+        }
+    }
+
+    private var providerName: String {
+        snapshot.provider.displayName
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(providerName)
+                    .font(.headline)
+                Text(snapshot.displayName)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                if snapshot.accountIdentity != snapshot.displayName {
+                    Text(snapshot.accountIdentity)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            if let errorDescription = snapshot.errorDescription {
+                Text(errorDescription)
+                    .font(.caption)
+                    .foregroundColor(.orange)
+                    .lineLimit(2)
+            }
+
+            if usageRows.isEmpty {
+                Text(emptyStateText)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else {
+                VStack(spacing: 5) {
+                    ForEach(usageRows) { row in
+                        HStack(spacing: 8) {
+                            Text(row.name)
+                                .font(.system(size: 12))
+                                .foregroundColor(.secondary)
+                            Spacer(minLength: 8)
+                            Text("\(Int(row.percentage.rounded()))%")
+                                .font(.system(size: 12, weight: .semibold))
+                                .monospacedDigit()
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.gray.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var emptyStateText: String {
+        if case .none = snapshot.payload {
+            return L.Usage.loading
+        }
+        return L.Error.noData
+    }
+
 }

--- a/Usage4Claude/Views/WebLogin/ClaudeOAuthCoordinator.swift
+++ b/Usage4Claude/Views/WebLogin/ClaudeOAuthCoordinator.swift
@@ -225,6 +225,7 @@ final class ClaudeOAuthCoordinator: ObservableObject {
             sessionKey: tokens.refreshToken,
             organizationId: stableOrgId,
             organizationName: displayName,
+            email: email.isEmpty ? nil : email,
             alias: nil,
             provider: .claude
         )

--- a/Usage4Claude/Views/WebLogin/CodexOAuthCoordinator.swift
+++ b/Usage4Claude/Views/WebLogin/CodexOAuthCoordinator.swift
@@ -156,6 +156,7 @@ final class CodexOAuthCoordinator: ObservableObject {
                 sessionKey: tokens.refreshToken,
                 organizationId: email.isEmpty ? (tokens.accountId ?? "") : email,
                 organizationName: displayName,
+                email: email.isEmpty ? nil : email,
                 alias: nil,
                 provider: .codex
             )

--- a/Usage4Claude/Views/WebLogin/CodexSilentRefreshCoordinator.swift
+++ b/Usage4Claude/Views/WebLogin/CodexSilentRefreshCoordinator.swift
@@ -31,6 +31,7 @@ final class CodexSilentRefreshCoordinator: NSObject {
     private var navigationDelegate: NavigationDelegate?
     private var timeoutTask: Task<Void, Never>?
     private var completion: ((Result<String, Error>) -> Void)?
+    private var refreshAccount: Account?
 
     private let timeoutInterval: TimeInterval = 25
     private let safariUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15"
@@ -41,13 +42,21 @@ final class CodexSilentRefreshCoordinator: NSObject {
 
     /// 触发静默刷新。成功时 Result.success 携带最新的 session-token 字符串。
     func refresh(completion: @escaping (Result<String, Error>) -> Void) {
+        guard let account = UserSettings.shared.currentCodexAccount else {
+            completion(.failure(UsageError.noCredentials))
+            return
+        }
+        refresh(for: account, completion: completion)
+    }
+
+    func refresh(for account: Account, completion: @escaping (Result<String, Error>) -> Void) {
         guard !isRefreshing else {
             Logger.settings.debug("CodexSilentRefresh: 刷新已在进行中，跳过")
             completion(.failure(UsageError.networkError))
             return
         }
 
-        let sessionToken = UserSettings.shared.codexSessionToken
+        let sessionToken = account.sessionKey
         guard !sessionToken.isEmpty else {
             completion(.failure(UsageError.noCredentials))
             return
@@ -55,6 +64,7 @@ final class CodexSilentRefreshCoordinator: NSObject {
 
         isRefreshing = true
         self.completion = completion
+        refreshAccount = account
 
         // 使用进程级共享 data store，与登录窗口的 WKWebView 共享同一套 cookie
         let config = WKWebViewConfiguration()
@@ -167,10 +177,17 @@ final class CodexSilentRefreshCoordinator: NSObject {
                 return
             }
 
-            let currentToken = UserSettings.shared.codexSessionToken
-            if newToken != currentToken {
+            guard let account = self.refreshAccount else {
+                self.finish(result: .failure(UsageError.noCredentials))
+                return
+            }
+            if newToken != account.sessionKey {
                 Logger.settings.notice("CodexSilentRefresh: 获取到新 session-token，静默写回 Keychain")
-                UserSettings.shared.silentlyUpdateCurrentCodexSessionToken(newToken)
+                UserSettings.shared.silentlyUpdateCodexSessionToken(
+                    newToken,
+                    for: account.id,
+                    replacing: account.sessionKey
+                )
             } else {
                 Logger.settings.info("CodexSilentRefresh: session-token 未变化（服务端未续期）")
             }
@@ -198,6 +215,7 @@ final class CodexSilentRefreshCoordinator: NSObject {
         webView?.navigationDelegate = nil
         webView = nil
         navigationDelegate = nil
+        refreshAccount = nil
         let cb = completion
         completion = nil
         cb?(result)

--- a/Usage4Claude/Views/WebLogin/CodexTokenRefreshCoordinator.swift
+++ b/Usage4Claude/Views/WebLogin/CodexTokenRefreshCoordinator.swift
@@ -34,13 +34,21 @@ final class CodexTokenRefreshCoordinator: NSObject {
 
     /// 刷新 accessToken。成功时 Result.success 携带新鲜的 accessToken 字符串。
     func refresh(completion: @escaping (Result<String, Error>) -> Void) {
+        guard let account = UserSettings.shared.currentCodexAccount else {
+            completion(.failure(UsageError.noCredentials))
+            return
+        }
+        refresh(for: account, completion: completion)
+    }
+
+    func refresh(for account: Account, completion: @escaping (Result<String, Error>) -> Void) {
         guard !isRefreshing else {
             Logger.settings.debug("CodexTokenRefresh: 刷新已在进行中，跳过")
             completion(.failure(UsageError.networkError))
             return
         }
 
-        let sessionToken = UserSettings.shared.codexSessionToken
+        let sessionToken = account.sessionKey
         guard !sessionToken.isEmpty else {
             completion(.failure(UsageError.noCredentials))
             return
@@ -108,11 +116,14 @@ final class CodexTokenRefreshCoordinator: NSObject {
             let chatgptURL = URL(string: "https://chatgpt.com")!
             let storedCookies = HTTPCookieStorage.shared.cookies(for: chatgptURL) ?? []
             if let newToken = CodexWebLoginCoordinator.extractSessionToken(from: storedCookies) {
-                let currentToken = UserSettings.shared.codexSessionToken
-                if newToken != currentToken {
+                if newToken != sessionToken {
                     Logger.settings.notice("CodexTokenRefresh: URLSession 检测到新 session-token，静默写回")
                     DispatchQueue.main.async {
-                        UserSettings.shared.silentlyUpdateCurrentCodexSessionToken(newToken)
+                        UserSettings.shared.silentlyUpdateCodexSessionToken(
+                            newToken,
+                            for: account.id,
+                            replacing: sessionToken
+                        )
                     }
                 } else {
                     Logger.settings.debug("CodexTokenRefresh: session-token 未变化")

--- a/Usage4Claude/Views/WebLogin/CodexWebLoginCoordinator.swift
+++ b/Usage4Claude/Views/WebLogin/CodexWebLoginCoordinator.swift
@@ -195,6 +195,7 @@ final class CodexWebLoginCoordinator: ObservableObject {
                     sessionKey: sessionToken,
                     organizationId: info.email,
                     organizationName: info.displayName,
+                    email: info.email.isEmpty ? nil : info.email,
                     alias: nil,
                     provider: .codex
                 )


### PR DESCRIPTION
## Summary

Usage4Claude can already store multiple Claude and Codex accounts, but the menu bar and usage popover only displayed the currently selected account for each provider. This PR makes usage tracking account-aware throughout the app, allowing every saved account to be monitored simultaneously.

## What changed

- The menu bar now shows a separate usage group for each saved Claude and Codex account, with no fixed account limit.
- The popover displays all accounts in a single scrollable view, including account identity, available limits, loading state, and account-specific errors.
- General settings let users choose which accounts appear in the menu bar. All accounts are shown by default; hidden accounts still refresh and remain available in the popover.
- Usage refreshes run concurrently, using one API client per account, so a request from one account does not cancel another's.
- Notifications, reset checks, cached usage, authentication refreshes, and errors are tracked per account rather than being tied to the selected account.
- Removing an account immediately removes its menu-bar and popover state, while failed refreshes keep the last successful usage visible.
- Stale Codex fallback callbacks are rejected after an account switch, preventing credentials or usage from being attached to the wrong account.

Existing accounts remain compatible. When an email is available, it is stored and shown in the popover; older accounts fall back to their existing organization name.

## Verification

- `swift test` — 144 tests passed
- `python3 scripts/check_l10n.py` — 7 languages, 355 keys each
- Unsigned Release build via `xcodebuild` — succeeded

Review: review-until-converge — manual correctness find/refutation + repository standards · 2 rounds · 1 correctness fixed · 1 quality/standards fixed · 0 deferred
