### PR TITLE
fix: don't fail the whole usage decode when five_hour is null

### DIFF
--- a/Tests/Usage4ClaudeCoreTests/UsageResponseTests.swift
+++ b/Tests/Usage4ClaudeCoreTests/UsageResponseTests.swift
@@ -5,7 +5,11 @@ import XCTest
 /// that backs the main /api/organizations/<id>/usage fetch.
 ///
 /// Specs the production code intends to honor:
-/// - 5-hour data is always parsed (utilization + resets_at).
+/// - 5-hour data is parsed when present (utilization + resets_at). The field
+///   is optional: some account types (Team accounts have been observed doing
+///   this) return `"five_hour": null` alongside every other limit field, and
+///   that alone must not fail decoding of the whole response — it degrades
+///   to `fiveHour == nil`, same as the opus/sonnet "no data" case.
 /// - 7-day always emits a placeholder. Every Claude account has a 7-day limit
 ///   even before usage starts; when `seven_day` is missing OR returns
 ///   (utilization=0, resets_at=null), the transform yields a 0% placeholder
@@ -70,6 +74,31 @@ final class UsageResponseTests: XCTestCase {
         let usage = try decode(json).toUsageData()
         XCTAssertEqual(usage.fiveHour?.percentage, 0)
         XCTAssertNil(usage.fiveHour?.resetsAt)
+    }
+
+    func testFiveHourNullDoesNotFailWholeResponseDecode() throws {
+        // Regression test for a report where a Team account's usage response
+        // came back with every limit field, including five_hour, set to null
+        // (only `extra_usage` — decoded by a separate response type — had
+        // real data). With `five_hour` previously declared non-optional,
+        // JSONDecoder threw `valueNotFound` on this single field and the
+        // production `try? decoder.decode(UsageResponse.self, ...)` call
+        // turned that into a total "failed to parse response data" failure,
+        // even though every other field decoded fine.
+        let json = """
+        {
+            "five_hour": null,
+            "seven_day": null,
+            "seven_day_oauth_apps": null,
+            "seven_day_opus": null,
+            "seven_day_sonnet": null
+        }
+        """
+        let usage = try decode(json).toUsageData()
+        XCTAssertNil(usage.fiveHour)
+        // The rest of the response still degrades gracefully, same as any
+        // other brand-new/empty account.
+        XCTAssertEqual(usage.sevenDay?.percentage, 0)
     }
 
     // MARK: - 7-day limit (always emits a placeholder)

--- a/Usage4Claude/Helpers/DiagnosticRunner.swift
+++ b/Usage4Claude/Helpers/DiagnosticRunner.swift
@@ -105,12 +105,13 @@ final class ClaudeDiagnosticRunner: DiagnosticRunner {
         }
 
         if let json = try? JSONDecoder().decode(UsageResponse.self, from: data) {
+            let fiveHourSummary = json.five_hour.map { "\($0.utilization)" } ?? "n/a"
             return DiagnosticStep(
                 name: stepName, success: true,
                 httpStatusCode: statusCode, responseTime: responseTime,
                 responseType: .json, errorType: nil, errorDescription: nil,
                 responseHeaders: headers,
-                responseBodyPreview: "Valid usage data received (utilization: \(json.five_hour.utilization)%)",
+                responseBodyPreview: "Valid usage data received (utilization: \(fiveHourSummary)%)",
                 cloudflareChallenge: false,
                 cfMitigated: headers["cf-mitigated"] != nil,
                 notes: nil

--- a/Usage4Claude/Models/ClaudeAPIResponseModels.swift
+++ b/Usage4Claude/Models/ClaudeAPIResponseModels.swift
@@ -49,7 +49,11 @@ nonisolated struct Organization: Codable, Sendable, Identifiable, Equatable {
 /// 对应 Claude API 返回的 JSON 结构
 nonisolated struct UsageResponse: Codable, Sendable {
     /// 5小时用量限制数据
-    let five_hour: LimitUsage
+    /// - Note: 绝大多数账号都会带上这个字段，但部分账号类型（如 Team）观察到
+    ///   API 会把它和其它限制字段一起返回 null。声明为可选，这样单个字段为
+    ///   null 不会让整条响应解码失败——之前 `try? decoder.decode(...)` 在这种
+    ///   情况下会直接返回 nil，导致整个用量拉取失败。
+    let five_hour: LimitUsage?
     /// 7天用量限制数据
     let seven_day: LimitUsage?
     /// 7天 OAuth 应用用量（暂未使用）
@@ -101,8 +105,13 @@ nonisolated struct UsageResponse: Codable, Sendable {
     /// - Returns: 转换后的 UsageData 实例
     /// - Note: 会自动处理时间四舍五入，确保显示准确
     func toUsageData() -> UsageData {
-        // 解析5小时限制数据
-        let fiveHourData = parseLimitData(five_hour)
+        // 解析5小时限制数据。与 opus/sonnet 一致：字段缺失时留空（nil），
+        // 而不是像 seven_day 那样伪造 0% 占位——我们并不知道该账号是否真的
+        // 存在这项限制，所以交给 UI 的既有 nil 处理逻辑隐藏这一行。
+        let fiveHourData: UsageData.LimitData? = five_hour.map { limit in
+            let parsed = parseLimitData(limit)
+            return UsageData.LimitData(percentage: parsed.percentage, resetsAt: parsed.resetsAt)
+        }
 
         // 解析7天限制数据。所有 Claude 账号都有 7 天限制；
         // 未开始使用时 API 可能返回 0 且无 resets_at，仍保留为 0% 占位。
@@ -165,7 +174,7 @@ nonisolated struct UsageResponse: Codable, Sendable {
         })
 
         return UsageData(
-            fiveHour: UsageData.LimitData(percentage: fiveHourData.percentage, resetsAt: fiveHourData.resetsAt),
+            fiveHour: fiveHourData,
             sevenDay: sevenDayData,
             weeklyModels: weeklyModels,
             extraUsage: nil  // Extra Usage 将在阶段5通过单独的 API 获取


### PR DESCRIPTION
I ran into issue #74 while poking around the open issues and got curious about the diagnostic payload the reporter attached — `five_hour`, `seven_day`, and every other limit field come back `null`, with only `extra_usage` populated (Team account). That's exactly the shape that makes `JSONDecoder` choke: `UsageResponse.five_hour` is declared as a non-optional `LimitUsage`, so a `null` there throws `valueNotFound`, and the app's `try? decoder.decode(UsageResponse.self, ...)` swallows that into the generic "failed to parse response data" message — which is precisely what the report shows.

I reproduced the decode failure locally against a JSON payload with the same null-field shape and confirmed it throws on unmodified `main`. This PR makes `five_hour` optional (matching how `seven_day`/`seven_day_opus`/`seven_day_sonnet` already handle missing data) and has `toUsageData()` degrade to `fiveHour == nil` instead of throwing — the same "hide the row, don't crash" pattern already used for opus/sonnet when their fields are absent. The UI already null-checks `data.fiveHour` everywhere it's read (`MenuBarIconRenderer`, `UsageDetailView`, `UsageRowComponents`, `NotificationManager`, ...), so nothing downstream needed to change.

I'm being upfront that I don't have a Team account, so I can't confirm this makes the other usage rows actually populate correctly end-to-end for that account type — only that a null `five_hour` no longer aborts the whole decode. If Team accounts turn out to have other shape differences further down (e.g. in `limits[]`), those would need a separate look with real data from someone who can reproduce them live.

## What changed
- `Usage4Claude/Models/ClaudeAPIResponseModels.swift`: `five_hour` is now `LimitUsage?`; `toUsageData()` maps it to `nil` when absent instead of force-parsing
- `Usage4Claude/Helpers/DiagnosticRunner.swift`: updates the one other read site (the success-path diagnostic preview string) for the new optional type
- `Tests/Usage4ClaudeCoreTests/UsageResponseTests.swift`: adds a regression test decoding a response with `five_hour: null` (plus the other fields from the report all null) and asserts it now succeeds with `fiveHour == nil`, and tightens the file's header doc comment to describe the field as optional

## Testing
- `swift test` — 129/129 passing (includes the new regression test)
- `python3 scripts/check_l10n.py` — clean, no new strings touched
- `xcodebuild build` on the `Usage4Claude-Debug` scheme — builds clean, no warnings
